### PR TITLE
meta: add `collection-requirements.yml`

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: community.general


### PR DESCRIPTION
This file is used by tox-lsr to install collections automatically during test runs. Since we will need the `redhat_subscription` & the `rhsm_*` modules available in the `community.general` collection, add that collection to the `collection-requirements.yml` file.

Signed-off-by: Pino Toscano <ptoscano@redhat.com>