### PR TITLE
tests: always disable cert validation when checking Candlepin

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -72,4 +72,4 @@
   uri:
     url: "https://{{ lsr_rhc_test_data.candlepin_host }}:{{ lsr_rhc_test_data.candlepin_port }}{{ lsr_rhc_test_data.candlepin_prefix }}"  # yamllint disable-line
     method: HEAD
-    validate_certs: "{{ not lsr_rhc_test_data.candlepin_insecure }}"
+    validate_certs: false


### PR DESCRIPTION
Properly checking that the SSL connection to Candlepin works requires also the CA of that Candlepin instance, which is generally not in the system CA store (but in /etc/rhsm/ca for subscription-manager).

Since this is only an existance check, disable the certificate validation. In case of SSL problems, the actual subscription-manager invocation will fail anyway.