### PR TITLE
Improve OS support/checking

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,8 @@ galaxy_info:
         - all
     - name: EL
       versions:
+        - 7
+        - 8
         - 9
 
   galaxy_tags:

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -14,6 +14,12 @@
 
 - name: Deploy Candlepin
   block:
+    - name: Skip on OSes not supported by Candlepin
+      meta: end_play
+      when:
+        - ansible_distribution in ["CentOS", "RedHat"]
+        - ansible_distribution_major_version | int > 8
+
     - name: Clone ansible-role-candlepin repo
       git:
         repo: https://github.com/candlepin/ansible-role-candlepin.git


### PR DESCRIPTION
- skip OSes not supported by Candlepin when deploying it
- claim to support EL7 and EL8 for now