### PR TITLE
Perform auto-attach when registering

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -18,3 +18,5 @@
     server_port: "{{ rhc_server.port | d(omit) }}"
     server_prefix: "{{ rhc_server.prefix | d(omit) }}"
     server_insecure: "{{ rhc_server.insecure | d(omit) }}"
+    auto_attach: "{{ true
+      if ( rhc_state | d('present') == 'present' ) else omit }}"


### PR DESCRIPTION
This makes entitlement mode working OOTB (at least in the majority of the cases) with no need to fiddle with pools. SCA works regardless of it.