### PR TITLE
tests: install some product certificates of deployed Candlepin

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -53,6 +53,21 @@
         name: tomcat
         enabled: true
 
+    - name: Ensure /etc/pki/product exists
+      file:
+        path: /etc/pki/product
+        state: directory
+        mode: 0755
+
+    - name: Copy product certificates
+      copy:
+        src: "/home/candlepin/devel/candlepin/generated_certs/{{ item }}.pem"
+        dest: "/etc/pki/product/{{ item }}.pem"
+        remote_src: true
+        mode: 0644
+      loop:
+        - "5050"
+
     - name: Set variables
       set_fact:
         lsr_rhc_test_data:


### PR DESCRIPTION
This way it will be possible to use the test products available with the test data of the deployed Candlepin.