### PR TITLE
Implement rhc_baseurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ rhc_server:
 - `insecure` specifies whether to disable the validation of the SSL certificate
   of the registration server
 
+    rhc_baseurl: ""
+
+The base URL for receiving content from the subscription server.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 rhc_auth: {}
+rhc_baseurl: null
 rhc_organization: null
 rhc_server: {}
 rhc_state: "present"

--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -6,6 +6,19 @@
     state: present
   when: rhc_state | d('present') == "present"
 
+- name: Change rhsm.baseurl
+  command:
+    argv:
+      - subscription-manager
+      - config
+      - "--rhsm.baseurl={{ rhc_baseurl }}"
+  changed_when: false
+  when:
+    - rhc_state | d("present") == "present"
+    - rhc_baseurl | d("") != ""
+    - rhc_baseurl is not none
+    - rhc_baseurl != omit
+
 - name: Call subscription-manager
   redhat_subscription:
     state: "{{ rhc_state | d('present') }}"

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,7 @@ lsr_rhc_test_data:
   reg_username: "username"
   reg_password: "password"
   reg_organization: "organization"
+  baseurl: "https://base-url"
 ```
 
 - `candlepin_host` & `candlepin_port` are the hostname & the port of Candlepin
@@ -26,6 +27,7 @@ lsr_rhc_test_data:
   of the user to use in the vast majority of the registration tests;
   `reg_organization` can be specified as `null` in case `reg_username` belongs
   to only one organization
+- `baseurl` is the base URL for receiving content
 
 To use this custom configuration, set the `LSR_RHC_TEST_DATA` environment
 variable to the full path of that file.

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -84,6 +84,7 @@
           reg_username: "admin"
           reg_password: "admin"
           reg_organization: "admin"
+          baseurl: "http://127.0.0.1:8080"
         cacheable: true
   when: lsr_rhc_test_data_file | length == 0
 


### PR DESCRIPTION
Add a parameter for specifying the base URL for the content received from the subscription server.

This is set as separate parameter on its own, because the redhat_subscription module both configures it and passes it as argument to "subscription-manager register --baseurl"; the problem with `--baseurl` is that subscription-manager parses it and then assumes https as protocol, breaking the original URL set by the user.

Extend the test setup so it is possible to specify it.