### PR TITLE
tests: enable content from deployed Candlepin

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -46,7 +46,7 @@
           vars:
             cp_configure_mariadb: false
             cp_configure_ruby: false
-            cp_deploy_args: "-g -a -f -t"
+            cp_deploy_args: "-g -a -f -t -r"
 
     - name: Enable tomcat
       service:
@@ -67,6 +67,12 @@
         mode: 0644
       loop:
         - "5050"
+
+    - name: Install GPG key for RPM repositories
+      get_url:
+        url: http://127.0.0.1:8080/RPM-GPG-KEY-candlepin
+        dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin
+        mode: 0644
 
     - name: Set variables
       set_fact:


### PR DESCRIPTION
When deploy Candlepin in the test system, tell it to also configure the repositories with test content for the test data (i.e. "-r" for the deploy script). This way it will be possible to simulate fetching actual content from it.

Fetch the GPG key for the repositories, so RPM can install the test packages.