### PR TITLE
Implement basic registration/unregistration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ rhc_repositories:
 
 A release to set for the system. Use `{"state":"absent"}` to actually unset the
 release set for the system.
+```
+rhc_insights:
+  state: present
+```
+
+Whether the system is connected to Insights; valid values are `present`
+(to ensure registration/connection), and `absent`.
+
 
     rhc_proxy: {}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 ---
 rhc_auth: {}
 rhc_baseurl: null
+rhc_insights:
+  state: present
 rhc_organization: null
 rhc_proxy: {}
 rhc_release: null

--- a/tasks/check-insights-status.yml
+++ b/tasks/check-insights-status.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Call insights status
+  command: insights-client --status
+  changed_when: false
+  register: __rhc_insights_status
+  failed_when: __rhc_insights_status.rc not in [0,1]

--- a/tasks/insights-client-unregistration.yml
+++ b/tasks/insights-client-unregistration.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Call insights status
+  include_tasks: check-insights-status.yml
+
+- name: Unregister insights-client
+  command: insights-client --unregister
+  when:
+    - >-
+      "This host is registered" in __rhc_insights_status.stdout
+      or "Registered" in __rhc_insights_status.stdout
+  register: __rhc_insights_unregister_result

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure required packages are installed
+  package:
+    name: insights-client
+    state: present
+
+- name: Call insights status
+  include_tasks: check-insights-status.yml
+
+- name: Register insights-client
+  command: insights-client --register
+  when:
+    - >-
+      "NOT" in __rhc_insights_status.stdout
+      or "unregistered" in __rhc_insights_status.stdout
+  register: __rhc_insights_registration_result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,5 +3,21 @@
 - name: Set ansible_facts required by role
   include_tasks: set_vars.yml
 
+- name: Handle insights unregistration
+  include_tasks: insights-client-unregistration.yml
+  when:
+  - ansible_distribution == "RedHat"
+  - >-
+    rhc_insights.state | d("present") == "absent"
+    or rhc_state | d("present") == "absent"
+  - '"insights-client" in ansible_facts.packages'
+
 - name: Handle system subscription
   include_tasks: subscription-manager.yml
+
+- name: Handle insights registration
+  include_tasks: insights-client.yml
+  when:
+  - ansible_distribution == "RedHat"
+  - rhc_insights.state | d("present") == "present"
+  - rhc_state | d("present") == "present"

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -5,3 +5,11 @@
     gather_subset: min
   when: not ansible_facts.keys() | list |
     intersect(__rhc_required_facts) == __rhc_required_facts
+
+- name: Check if insights-client is installed
+  package_facts:
+  when:
+    - ansible_distribution == "RedHat"
+    - >-
+      rhc_insights.state | d("present") == "absent"
+      or rhc_state | d("present") == "absent"

--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -1,16 +1,24 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Basic register/unregister
+- name: Basic insights-client register/unregister
   hosts: all
   gather_facts: true
-  become: true
-  tags:
-    - tests::slow
+
   tasks:
-    - name: Setup Candlepin
-      import_tasks: tasks/setup_candlepin.yml
+    - name: Skip when running with embedded Candlepin
+      meta: end_play
+      when:
+        - lookup('env', 'LSR_RHC_TEST_DATA') | length == 0
+      delegate_to: 127.0.0.1
+      become: false
 
-    - name: Register
+    - name: Import test data
+      include_vars:
+        file: "{{ lookup('env', 'LSR_RHC_TEST_DATA') }}"
+      delegate_to: 127.0.0.1
+      become: false
+
+    - name: Register insights
       include_role:
         name: linux-system-roles.rhc
       vars:
@@ -19,7 +27,7 @@
             username: "{{ lsr_rhc_test_data.reg_username }}"
             password: "{{ lsr_rhc_test_data.reg_password }}"
         rhc_insights:
-          state: absent
+          state: present
         rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
         rhc_server:
           hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -27,7 +35,7 @@
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
 
-    - name: Register (noop)
+    - name: Register insights (noop)
       include_role:
         name: linux-system-roles.rhc
       vars:
@@ -36,7 +44,7 @@
             username: "{{ lsr_rhc_test_data.reg_username }}"
             password: "{{ lsr_rhc_test_data.reg_password }}"
         rhc_insights:
-          state: absent
+          state: present
         rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
         rhc_server:
           hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -44,13 +52,13 @@
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
 
-    - name: Unregister
+    - name: Unregister insights
       include_role:
         name: linux-system-roles.rhc
       vars:
         rhc_state: absent
 
-    - name: Unregister (noop)
+    - name: Unregister insights (noop)
       include_role:
         name: linux-system-roles.rhc
       vars:

--- a/tests/tests_proxy.yml
+++ b/tests/tests_proxy.yml
@@ -23,6 +23,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -51,6 +53,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -79,6 +83,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -105,6 +111,8 @@
           login:
             username: "{{ lsr_rhc_test_data.reg_username }}"
             password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_insights:
+          state: absent
         rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
         rhc_server:
           hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -136,6 +144,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -164,6 +174,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -194,6 +206,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -224,6 +238,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -252,6 +268,8 @@
           login:
             username: "{{ lsr_rhc_test_data.reg_username }}"
             password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_insights:
+          state: absent
         rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
         rhc_server:
           hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -278,6 +296,8 @@
           login:
             username: "{{ lsr_rhc_test_data.reg_username }}"
             password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_insights:
+          state: absent
         rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
         rhc_server:
           hostname: "{{ lsr_rhc_test_data.candlepin_host }}"

--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -25,6 +25,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -67,6 +69,8 @@
               include_role:
                 name: linux-system-roles.rhc
               vars:
+                rhc_insights:
+                  state: absent
                 # look like a valid release number, hopefully it will never
                 # be used!
                 rhc_release: "1.99"
@@ -84,6 +88,8 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
+            rhc_insights:
+              state: absent
             rhc_release: "{{ lsr_rhc_test_data.release }}"
 
         - name: Get set release
@@ -98,6 +104,8 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
+            rhc_insights:
+              state: absent
             rhc_release: "{{ lsr_rhc_test_data.release }}"
 
       always:

--- a/tests/tests_repositories.yml
+++ b/tests/tests_repositories.yml
@@ -20,6 +20,8 @@
               login:
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
@@ -57,6 +59,8 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
+            rhc_insights:
+              state: absent
             rhc_repositories:
               - {name: "*", state: disabled}
 


### PR DESCRIPTION
Add a minimal task to call "insights-client" via command module to register and unregister.

Extend the API with basic parameters:
- add "rhc_insights_state" for the registration of insights.

Add a very simple integration test that tries to register and unregister. Each step is done twice to verify the idempotency of the role on status changes.

Signed-off-by: Alba Hita Catala <ahitacat@redhat.com>