### PR TITLE
Fix string checking

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -15,7 +15,7 @@
   changed_when: false
   when:
     - rhc_state | d("present") == "present"
-    - rhc_baseurl | d("") != ""
+    - rhc_baseurl | d("") | length > 0
     - rhc_baseurl is not none
     - rhc_baseurl != omit
 


### PR DESCRIPTION
Do not compare a string with an empty string, rather check it is not empty; fix an issue reported by yamllint.

Fixes commit 8ac253b971bb4544feb392ab0a1fc9289596bf38

Signed-off-by: Pino Toscano <ptoscano@redhat.com>