### PR TITLE
tests: install Candlepin CA cert for subscription-manager

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -74,13 +74,20 @@
         dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin
         mode: 0644
 
+    - name: Copy Candlepin CA certificate for subscription-manager
+      copy:
+        src: /etc/candlepin/certs/candlepin-ca.crt
+        dest: /etc/rhsm/ca/candlepin-ca.pem
+        remote_src: true
+        mode: 0644
+
     - name: Set variables
       set_fact:
         lsr_rhc_test_data:
           candlepin_host: 127.0.0.1
           candlepin_port: 8443
           candlepin_prefix: /candlepin
-          candlepin_insecure: true
+          candlepin_insecure: false
           reg_username: "admin"
           reg_password: "admin"
           reg_organization: "admin"


### PR DESCRIPTION
When deploying Candlepin, copy the autogenerated CA certificate for Candlepin to the CA store of subscription-manager. This allows subscription-manager to validate the SSL connection to Candlepin, and thus there is no more need to set the connection as insecure.