### PR TITLE
Fix checks when setting rhsm.baseurl

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -15,9 +15,9 @@
   changed_when: false
   when:
     - rhc_state | d("present") == "present"
-    - rhc_baseurl | d("") | length > 0
     - rhc_baseurl is not none
     - rhc_baseurl != omit
+    - rhc_baseurl | string | length > 0
 
 - name: Call subscription-manager
   redhat_subscription:


### PR DESCRIPTION
Since the default is null, then check for None or omit values before
checking whether it is undefined or an empty string.

Fix also the empty string check:
- remove the "default()" filter, as it should be defined as role
  default variable
- cast it as string, so numbers will not cause the "length" filter to
  bomb out