### PR TITLE
meta: temporarily add tests requirements for the role

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,2 +1,5 @@
 collections:
+  - name: ansible.posix
   - name: community.general
+  - name: community.mysql
+  - name: community.postgresql


### PR DESCRIPTION
The test infra does not support tests/collection-requirements.yml yet; hence, for now pull the extra collections needed for the tests as dependencies for the role.