### PR TITLE
tests: ensure `/etc/rhsm/ca` exists w/ deployed candlepin

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -53,11 +53,14 @@
         name: tomcat
         enabled: true
 
-    - name: Ensure /etc/pki/product exists
+    - name: Ensure directories exist
       file:
-        path: /etc/pki/product
+        path: "{{ item }}"
         state: directory
         mode: 0755
+      loop:
+        - /etc/pki/product
+        - /etc/rhsm/ca
 
     - name: Copy product certificates
       copy:


### PR DESCRIPTION
`/etc/rhsm/ca` is created by `subscription-manager-rhsm-certificates`; on non-RHEL systems (Fedora, CentOS, etc),
`subscription-manager-rhsm-certificates` is not installed by default, and thus that directory does not exist. Since we want to copy certificates there, ensure it exists even before installing `subscription-manager-rhsm-certificates`.

Refactor/repurpose the existing task for that.