### PR TITLE
Use FQCN for modules in community.general

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -20,7 +20,7 @@
     - rhc_baseurl | string | length > 0
 
 - name: Call subscription-manager
-  redhat_subscription:
+  community.general.redhat_subscription:
     state: "{{ rhc_state | d('present') }}"
     username: "{{ rhc_auth.login.username | d(omit) }}"
     password: "{{ rhc_auth.login.password | d(omit) }}"
@@ -39,7 +39,7 @@
     - rhc_state | d("present") == "present"
   block:
     - name: Configure repositories
-      rhsm_repository:
+      community.general.rhsm_repository:
         name: "{{ item.name }}"
         state: "{{ item.state }}"
         purge: no


### PR DESCRIPTION
Older Ansible versions ships with those modules embedded, and thus will prefer them even when installing the `community.general` collection. Hence, qualify those modules, so we force their versions in `community.general`.

Thanks to Richard Megginson for the hint!