### PR TITLE
Implement rhc_proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ rhc_repositories:
 A release to set for the system. Use `{"state":"absent"}` to actually unset the
 release set for the system.
 
+    rhc_proxy: {}
+
+The details of the proxy server to use for connecting:
+```yaml
+rhc_proxy:
+  hostname: "proxy-hostname"
+  port: 4321
+  username: "proxy-hostname"
+  password: "proxy-password"
+```
+- `hostname` is the hostname of the proxy server
+- `port` is the port to which connect to on the proxy server
+- `username` is the username to use for authenticating on the proxy server;
+  it can be not specified if the proxy server does not require authentication
+- `password` is the password to use for authenticating on the proxy server;
+  it can be not specified if the proxy server does not require authentication
+
+Use `{"state":"absent"}` to reset all the proxy configurations to empty
+(effectively disabling the proxy server).
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 rhc_auth: {}
 rhc_baseurl: null
 rhc_organization: null
+rhc_proxy: {}
 rhc_release: null
 rhc_repositories: []
 rhc_server: {}

--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -54,6 +54,34 @@
            and __rhc_subman_identity.rc == 1
            and rhc_release != __rhc_state_absent )
       else omit }}"
+    server_proxy_hostname: "{% if rhc_proxy == __rhc_state_absent -%}
+      {{ __rhc_empty_string }}
+      {%-   elif 'hostname' not in rhc_proxy -%}
+      {{ omit }}
+      {%-   else -%}
+      {{ rhc_proxy.hostname }}
+      {%- endif %}"
+    server_proxy_port: "{% if rhc_proxy == __rhc_state_absent -%}
+      {{ __rhc_empty_string }}
+      {%-   elif 'port' not in rhc_proxy -%}
+      {{ omit }}
+      {%-   else -%}
+      {{ rhc_proxy.port }}
+      {%- endif %}"
+    server_proxy_user: "{% if rhc_proxy == __rhc_state_absent -%}
+      {{ __rhc_empty_string }}
+      {%-   elif 'username' not in rhc_proxy -%}
+      {{ omit }}
+      {%-   else -%}
+      {{ rhc_proxy.username }}
+      {%- endif %}"
+    server_proxy_password: "{% if rhc_proxy == __rhc_state_absent -%}
+      {{ __rhc_empty_string }}
+      {%-   elif 'password' not in rhc_proxy -%}
+      {{ omit }}
+      {%-   else -%}
+      {{ rhc_proxy.password }}
+      {%- endif %}"
 
 - name: Configure subscribed system
   when:

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,16 @@ lsr_rhc_test_data:
     - {name: "repo1", state: enabled}
     - {name: "repo2", state: disabled}
   release: "some-release"
+  proxy_noauth_hostname: proxy-without-auth.hostname
+  proxy_noauth_port: port
+  proxy_auth_hostname: proxy-requiring-auth.hostname
+  proxy_auth_port: port
+  proxy_auth_username: "proxy-username"
+  proxy_auth_password: "proxy-password"
+  proxy_nonworking_hostname: must-not-exist.hostname
+  proxy_nonworking_port: invalid-port
+  proxy_nonworking_username: "wrong-username"
+  proxy_nonworking_password: "wrong-password"
 ```
 
 - `candlepin_host` & `candlepin_port` are the hostname & the port of Candlepin
@@ -37,6 +47,15 @@ lsr_rhc_test_data:
   `rhc_repositories` parameter of the `rhc` role
 - `release` is a release to set for the system; it has the same format of the
   `rhc_release` parameter of the `rhc` role
+- the various `proxy_*` variables represent proxy-related bits:
+   - `proxy_noauth_hostname` & `proxy_noauth_port` are the hostname & the port
+     of a proxy server that does not require authentication
+   - `proxy_auth_hostname`, `proxy_auth_port`, `proxy_auth_username` &
+     `proxy_auth_password` are the hostname & the port of a proxy server that
+      requires authentication, together with the credentials for it
+   - `proxy_nonworking_hostname`, `proxy_nonworking_port`,
+     `proxy_nonworking_username` & `proxy_nonworking_password` are wrong details
+     of proxy server configuration bits
 
 To use this custom configuration, set the `LSR_RHC_TEST_DATA` environment
 variable to the full path of that file.

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -99,6 +99,16 @@
             - {name: "admin-content-label-5051", state: enabled}
             - {name: "content-label-32060", state: disabled}
           release: null  # no releases in Candlepin test data
+          proxy_noauth_hostname: localhost
+          proxy_noauth_port: 3128
+          proxy_auth_hostname: localhost
+          proxy_auth_port: 3130
+          proxy_auth_username: "proxyuser"
+          proxy_auth_password: "proxyuser"
+          proxy_nonworking_hostname: "wrongproxy"
+          proxy_nonworking_port: 4000
+          proxy_nonworking_username: "wrong-proxyuser"
+          proxy_nonworking_password: "wrong-proxypassword"
         cacheable: true
   when: lsr_rhc_test_data_file | length == 0
 

--- a/tests/tasks/setup_squid.yml
+++ b/tests/tasks/setup_squid.yml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Install and configure squid
+  when:
+    - lsr_rhc_test_data.proxy_noauth_hostname == "localhost"
+  block:
+    - name: Install packages for squid
+      package:
+        name:
+          - squid
+          - httpd-tools
+        state: present
+
+    - name: Check the status of the backup of configuration
+      stat:
+        path: /etc/squid/squid.conf.BACKUP
+      register: squid_conf_backup_stat
+
+    - name: Backup the configuration
+      copy:
+        src: /etc/squid/squid.conf
+        dest: /etc/squid/squid.conf.BACKUP
+        remote_src: true
+        mode: 0644
+      when:
+        - not squid_conf_backup_stat.stat.exists
+
+    - name: Copy the pristine configuration back
+      copy:
+        src: /etc/squid/squid.conf.BACKUP
+        dest: /etc/squid/squid.conf
+        remote_src: true
+        mode: 0644
+      when:
+        - squid_conf_backup_stat.stat.exists
+
+    - name: Open the Candlepin port
+      lineinfile:
+        path: /etc/squid/squid.conf
+        regexp: "^acl SSL_ports port {{ lsr_rhc_test_data.candlepin_port }}"
+        insertbefore: "^acl Safe_ports "
+        line: >-
+          acl SSL_ports port {{ lsr_rhc_test_data.candlepin_port }} # Candlepin
+
+    - name: Setup no authentication
+      when:
+        - not (authentication | d(false))
+      block:
+        - name: Set the port
+          lineinfile:
+            path: /etc/squid/squid.conf
+            regexp: "^http_port "
+            line: "http_port {{ lsr_rhc_test_data.proxy_noauth_port }}"
+
+    - name: Setup authenticated
+      when:
+        - authentication | d(false)
+      block:
+        - name: Create the new passwd file
+          command:
+            argv:
+              - htpasswd
+              - "-c"
+              - "-b"
+              - "-m"
+              - /etc/squid/passwd
+              - "{{ lsr_rhc_test_data.proxy_auth_username }}"
+              - "{{ lsr_rhc_test_data.proxy_auth_password }}"
+
+        - name: Set the port
+          lineinfile:
+            path: /etc/squid/squid.conf
+            regexp: "^http_port "
+            line: "http_port {{ lsr_rhc_test_data.proxy_auth_port }}"
+
+        - name: Insert auth config into configuration
+          blockinfile:
+            path: /etc/squid/squid.conf
+            # yamllint disable rule:line-length
+            block: |
+              auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwd
+              auth_param basic realm squid realm
+            # yamllint enable rule:line-length
+
+    - name: Restart squid
+      service:
+        name: squid
+        state: restarted

--- a/tests/tests_proxy.yml
+++ b/tests/tests_proxy.yml
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Basic proxy test
+  hosts: all
+  gather_facts: true
+  become: true
+  tags:
+    - tests::slow
+  tasks:
+    - name: Setup Candlepin
+      import_tasks: tasks/setup_candlepin.yml
+
+    - name: Setup Squid
+      import_tasks: tasks/setup_squid.yml
+
+    - name: Try to register (wrong host, wrong port)
+      block:
+        - name: Register (wrong host, wrong port)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_proxy:
+              hostname: "{{ lsr_rhc_test_data.proxy_nonworking_hostname }}"
+              port: "{{ lsr_rhc_test_data.proxy_nonworking_port }}"
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert registration failed
+          assert:
+            that: true
+
+    - name: Try to register (wrong host)
+      block:
+        - name: Register (wrong host)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_proxy:
+              hostname: "{{ lsr_rhc_test_data.proxy_nonworking_hostname }}"
+              port: "{{ lsr_rhc_test_data.proxy_noauth_port }}"
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert registration failed
+          assert:
+            that: true
+
+    - name: Try to register (wrong port)
+      block:
+        - name: Register (wrong port)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_proxy:
+              hostname: "{{ lsr_rhc_test_data.proxy_noauth_hostname }}"
+              port: "{{ lsr_rhc_test_data.proxy_nonworking_port }}"
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert registration failed
+          assert:
+            that: true
+
+    - name: Register (no authentication)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          login:
+            username: "{{ lsr_rhc_test_data.reg_username }}"
+            password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_proxy:
+          hostname: "{{ lsr_rhc_test_data.proxy_noauth_hostname }}"
+          port: "{{ lsr_rhc_test_data.proxy_noauth_port }}"
+
+    - name: Unregister
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_state: absent
+
+    - name: Setup authenticated Squid
+      import_tasks: tasks/setup_squid.yml
+      vars:
+        authentication: true
+
+    - name: Try to register (missing credentials)
+      block:
+        - name: Register (missing credentials)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_proxy:
+              hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+              port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert registration failed
+          assert:
+            that: true
+
+    - name: Try to register (wrong username, wrong password)
+      block:
+        - name: Register (wrong username, wrong password)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_proxy:
+              hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+              port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
+              username: "{{ lsr_rhc_test_data.proxy_nonworking_username }}"
+              password: "{{ lsr_rhc_test_data.proxy_nonworking_password }}"
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert registration failed
+          assert:
+            that: true
+
+    - name: Try to register (wrong username)
+      block:
+        - name: Register (wrong username)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_proxy:
+              hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+              port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
+              username: "{{ lsr_rhc_test_data.proxy_nonworking_username }}"
+              password: "{{ lsr_rhc_test_data.proxy_auth_password }}"
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert registration failed
+          assert:
+            that: true
+
+    - name: Try to register (wrong password)
+      block:
+        - name: Register (wrong password)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_proxy:
+              hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+              port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
+              username: "{{ lsr_rhc_test_data.proxy_auth_username }}"
+              password: "{{ lsr_rhc_test_data.proxy_nonworking_password }}"
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert registration failed
+          assert:
+            that: true
+
+    - name: Register (authentication)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          login:
+            username: "{{ lsr_rhc_test_data.reg_username }}"
+            password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_proxy:
+          hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+          port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
+          username: "{{ lsr_rhc_test_data.proxy_auth_username }}"
+          password: "{{ lsr_rhc_test_data.proxy_auth_password }}"
+
+    - name: Unregister
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_state: absent
+
+    - name: Register (without proxy)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          login:
+            username: "{{ lsr_rhc_test_data.reg_username }}"
+            password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_proxy: {"state":"absent"}
+
+    - name: Unregister
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_state: absent

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,3 +13,6 @@ __rhc_state_absent:
 # credentials to the 'redhat_subscription' module, even when no registration
 # is needed
 __rhc_fake_credential: "this-is-not-a-credential!"
+
+# empty string, used in case a variable is needed for an empty string
+__rhc_empty_string: ""


### PR DESCRIPTION
Add a parameter for configuring the proxy server used for connecting.

The syntax of the 'rhc_proxy' parameter is particular:
- 'rhc_proxy: {"state":"absent"}': resets the proxy configuration to
  the default one (i.e. no proxy)
- if an attribute is not specified in 'rhc_proxy', then it is not
  changed
- if an attribute is specified in 'rhc_proxy', then it is set to that
Because of this, there is some jinja gymnastic needed to all the
'server_proxy_*' parameters of the 'redhat_subscription' module to
either omit, set as empty (using a helper empty variable), or use the
passed value.

Make sure to test this:
- extend the test setup with variables related to unauthenticated,
  authenticated, and non-working proxy servers
- add an helper script to deploy/configure squid in the test system;
  having the proxy server in the same system does not allow the test
  to properly check as if it was on a different system, however this
  is the best that can be done with a all-in-one-system setup
- add a new test to verify:
  - various combinations of non-working proxy details, for both
    unauthenticated, and authenticated proxy servers, lead to
    registration failures
  - using correct details works fine
  - resetting the proxy server works fine too