### PR TITLE
Workaround redhat_subscription requiring creds even when unneeded

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -31,8 +31,14 @@
 - name: Call subscription-manager
   community.general.redhat_subscription:
     state: "{{ rhc_state | d('present') }}"
-    username: "{{ rhc_auth.login.username | d(omit) }}"
-    password: "{{ rhc_auth.login.password | d(omit) }}"
+    username: "{{ __rhc_fake_credential
+      if ( rhc_state | d('present') == 'present'
+           and __rhc_subman_identity.rc == 0 )
+      else ( rhc_auth.login.username | d(omit) ) }}"
+    password: "{{ __rhc_fake_credential
+      if ( rhc_state | d('present') == 'present'
+           and __rhc_subman_identity.rc == 0 )
+      else ( rhc_auth.login.password | d(omit) ) }}"
     activationkey: "{{ rhc_auth.activation_keys.keys | join(',')
       if ( rhc_auth.activation_keys.keys is defined ) else omit }}"
     org_id: "{{ rhc_organization | d(omit) }}"

--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -45,11 +45,6 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
-            # TODO: make it work without rhc_auth
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_release: {"state":"absent"}
 
         - name: Get set release
@@ -64,11 +59,6 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
-            # TODO: make it work without rhc_auth
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_release: {"state":"absent"}
 
         - name: Check invalid releases cannot be set
@@ -77,11 +67,6 @@
               include_role:
                 name: linux-system-roles.rhc
               vars:
-                # TODO: make it work without rhc_auth
-                rhc_auth:
-                  login:
-                    username: "{{ lsr_rhc_test_data.reg_username }}"
-                    password: "{{ lsr_rhc_test_data.reg_password }}"
                 # look like a valid release number, hopefully it will never
                 # be used!
                 rhc_release: "1.99"
@@ -99,11 +84,6 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
-            # TODO: make it work without rhc_auth
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_release: "{{ lsr_rhc_test_data.release }}"
 
         - name: Get set release
@@ -118,11 +98,6 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
-            # TODO: make it work without rhc_auth
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_release: "{{ lsr_rhc_test_data.release }}"
 
       always:

--- a/tests/tests_repositories.yml
+++ b/tests/tests_repositories.yml
@@ -57,11 +57,6 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
-            # TODO: make it work without rhc_auth
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_repositories:
               - {name: "*", state: disabled}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,3 +8,8 @@ __rhc_required_facts:
 
 __rhc_state_absent:
   state: absent
+
+# this is a placeholder/fake credential to use in case we need to pass
+# credentials to the 'redhat_subscription' module, even when no registration
+# is needed
+__rhc_fake_credential: "this-is-not-a-credential!"


### PR DESCRIPTION
The 'redhat_subscription' module currently requires parameters for credentials in case state=present. This applies also in case the system is already registered (and force_register=false), being then effectively unused. This is proposed as change to 'redhat_subscription' as: https://github.com/ansible-collections/community.general/pull/5664

In the meanwhile, workaround this situation locally in the role:
- add a fake credential string as private variable
- pass the fake credential string to both 'username' and 'password' in case rhc_state=present and the system is already registered

This way, all the users of the role do not need to specify credentials when not needed; this reflects in the tests, from which it is possible to drop the extra credentials.