### PR TITLE
tests: drop extra 'rhc_organization' parameter

### DIFF
--- a/tests/tests_repositories.yml
+++ b/tests/tests_repositories.yml
@@ -57,7 +57,6 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
-            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_repositories:
               - {name: "*", state: disabled}
 


### PR DESCRIPTION
Followup of commit 1035e8da1a056996ab8fea2467dca9736eeb657e as additional credential previously needed (together with 'rhc_auth').