### PR TITLE
Add check for non-inclusive language

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -24,6 +24,7 @@
     - name: Clone ansible-role-candlepin repo
       git:
         repo: https://github.com/candlepin/ansible-role-candlepin.git
+        # wokeignore:rule=master
         version: master
         dest: "{{ playbook_dir }}/roles/candlepin"
       delegate_to: 127.0.0.1


### PR DESCRIPTION
Add a check for usage of terms and language that is considered
non-inclusive. We are using the woke tool for this with a wordlist
that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml

tests/tasks/setup_candlepin.yml - cleanup non-inclusive words.