### PR TITLE
Implement insights "force_register" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,19 @@ rhc_repositories:
 
 A release to set for the system. Use `{"state":"absent"}` to actually unset the
 release set for the system.
-```
-rhc_insights:
-  state: present
-```
+
+    rhc_insights:
+      state: present
+
 
 Whether the system is connected to Insights; valid values are `present`
 (to ensure registration/connection), and `absent`.
 
+    rhc_inisghts:
+      force_register: present
+
+To force a registration of insights-client. This will provide a fresh registration
+of the client. 
 
     rhc_proxy: {}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ rhc_auth: {}
 rhc_baseurl: null
 rhc_insights:
   state: present
+  force_register: false
 rhc_organization: null
 rhc_proxy: {}
 rhc_release: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
   - >-
     rhc_insights.state | d("present") == "absent"
     or rhc_state | d("present") == "absent"
+    or rhc_insights.force_register
   - '"insights-client" in ansible_facts.packages'
 
 - name: Handle system subscription

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -13,3 +13,4 @@
     - >-
       rhc_insights.state | d("present") == "absent"
       or rhc_state | d("present") == "absent"
+      or rhc_insights.force_register

--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -63,3 +63,10 @@
         name: linux-system-roles.rhc
       vars:
         rhc_state: absent
+
+    - name: Force insights registration
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_insights:
+          force_register: true


### PR DESCRIPTION
Add a parameter for force registration of insights. This will unregister and register the system insights-client.

Extend the API with the  parameter:
-  `rhc_insights.force_register` this parameter is a boolean.

By default, this parameter is false. Only set to true to perform force registration.

Signed-off-by: Alba Hita Catala <ahitacat@redhat.com>