### PR TITLE
tests: add missing "rhc_insights.state: absent" [citest skip]

### DIFF
--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -47,6 +47,8 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
+            rhc_insights:
+              state: absent
             rhc_release: {"state":"absent"}
 
         - name: Get set release
@@ -61,6 +63,8 @@
           include_role:
             name: linux-system-roles.rhc
           vars:
+            rhc_insights:
+              state: absent
             rhc_release: {"state":"absent"}
 
         - name: Check invalid releases cannot be set


### PR DESCRIPTION
Add missing disabling of Insights in few "rhc" usages in tests_release, so the test really does not try to register to Insights.

Followup of commit bdcb3250caa38166fca9c96e8099c71e9a2ebe8b.

`[citest skip]` because `tests/tests_release.yml` is not tested in CI (there are no releases available in the self-deployed Candlepin).