### PR TITLE
Implement `rhc_state: reconnect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ includes these collections/modules, you should have to do nothing.
     rhc_state: present
 
 Whether the system is connected to Red Hat; valid values are `present`
-(to ensure registration/connection), and `absent`.
+(to ensure registration/connection), `absent`, and `reconnect`.
+
+When using `reconnect`, the system will be unregistered/disconnected in case
+it was already registered/connected; because of this, the role will always
+report a "changed" status.
 
     rhc_organization: "your-organization"
 

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -7,11 +7,14 @@
 
 - name: Call insights status
   include_tasks: check-insights-status.yml
+  when:
+    - rhc_state | d("present") != "reconnect"
 
 - name: Register insights-client
   command: insights-client --register
   when:
     - >-
-      "NOT" in __rhc_insights_status.stdout
+      rhc_state | d("present") == "reconnect"
+      or "NOT" in __rhc_insights_status.stdout
       or "unregistered" in __rhc_insights_status.stdout
   register: __rhc_insights_registration_result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   - ansible_distribution == "RedHat"
   - >-
     rhc_insights.state | d("present") == "absent"
-    or rhc_state | d("present") == "absent"
+    or rhc_state | d("present") in ["absent", "reconnect"]
   - '"insights-client" in ansible_facts.packages'
 
 - name: Handle system subscription
@@ -20,4 +20,4 @@
   when:
   - ansible_distribution == "RedHat"
   - rhc_insights.state | d("present") == "present"
-  - rhc_state | d("present") == "present"
+  - rhc_state | d("present") in ["present", "reconnect"]

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -12,4 +12,4 @@
     - ansible_distribution == "RedHat"
     - >-
       rhc_insights.state | d("present") == "absent"
-      or rhc_state | d("present") == "absent"
+      or rhc_state | d("present") in ["absent", "reconnect"]

--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -11,6 +11,8 @@
     argv:
       - subscription-manager
       - identity
+  when:
+    - rhc_state | d("present") == "present"
   register: __rhc_subman_identity
   changed_when: false
   failed_when: __rhc_subman_identity.rc not in [0, 1]
@@ -23,7 +25,7 @@
       - "--rhsm.baseurl={{ rhc_baseurl }}"
   changed_when: false
   when:
-    - rhc_state | d("present") == "present"
+    - rhc_state | d("present") in ["present", "reconnect"]
     - rhc_baseurl is not none
     - rhc_baseurl != omit
     - rhc_baseurl | string | length > 0
@@ -31,7 +33,9 @@
 - name: Call subscription-manager
   # noqa jinja[spacing]
   community.general.redhat_subscription:
-    state: "{{ rhc_state | d('present') }}"
+    state: "{{ 'present'
+      if (rhc_state | d('present') == 'reconnect')
+      else rhc_state | d('present') }}"
     username: "{{ __rhc_fake_credential
       if (rhc_state | d('present') == 'present'
            and __rhc_subman_identity.rc == 0)
@@ -49,10 +53,9 @@
     server_insecure: "{{ omit if (rhc_server.insecure | d(omit) == omit)
       else rhc_server.insecure | ternary('1', '0') }}"
     auto_attach: "{{ true
-      if (rhc_state | d('present') == 'present') else omit }}"
+      if (rhc_state | d('present') in ['present', 'reconnect']) else omit }}"
     release: "{{ rhc_release
-      if (rhc_state | d('present') == 'present'
-           and __rhc_subman_identity.rc == 1
+      if (rhc_state | d('present') != 'absent'
            and rhc_release != __rhc_state_absent)
       else omit }}"
     server_proxy_hostname: "{% if rhc_proxy == __rhc_state_absent -%}
@@ -83,15 +86,17 @@
       {%-   else -%}
       {{ rhc_proxy.password }}
       {%- endif %}"
+    force_register: "{{ rhc_state | d('present') == 'reconnect' }}"
 
 - name: Configure subscribed system
   when:
-    - rhc_state | d("present") == "present"
+    - rhc_state | d("present") in ["present", "reconnect"]
   block:
     - name: Set the release
       community.general.rhsm_release:
         release: "{{ rhc_release }}"
       when:
+        - rhc_state | d("present") == "present"
         - __rhc_subman_identity.rc == 0
         - rhc_release != __rhc_state_absent
 
@@ -99,6 +104,7 @@
       community.general.rhsm_release:
         release: null
       when:
+        - rhc_state | d("present") == "present"
         - __rhc_subman_identity.rc == 0
         - rhc_release == __rhc_state_absent
 

--- a/tests/tasks/get_insights_uuid.yml
+++ b/tests/tasks/get_insights_uuid.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Slurp /etc/insights-client/machine-id
+  slurp:
+    src: /etc/insights-client/machine-id
+  register: test_insights_uuid_slurp
+
+- name: Set /etc/insights-client/machine-id into variable
+  set_fact:
+    test_insights_uuid: "{{ test_insights_uuid_slurp['content'] | b64decode }}"

--- a/tests/tasks/get_rhsm_uuid.yml
+++ b/tests/tasks/get_rhsm_uuid.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Run subscription-manager identity
+  shell: |
+    set -euo pipefail
+    subscription-manager identity |
+    awk '/^system identity: / {print $3}'
+  register: test_rhsm_uuid
+  changed_when: false

--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -52,6 +52,41 @@
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
 
+    - name: Get insights UUID
+      include_tasks: tasks/get_insights_uuid.yml
+
+    - name: Rename the insights UUID to test_insights_uuid_before
+      set_fact:
+        test_insights_uuid_before: "{{ test_insights_uuid }}"
+
+    - name: Register (force)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          login:
+            username: "{{ lsr_rhc_test_data.reg_username }}"
+            password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_state: reconnect
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+    - name: Get insights UUID
+      include_tasks: tasks/get_insights_uuid.yml
+
+    - name: Rename the insights UUID to test_insights_uuid_after
+      set_fact:
+        test_insights_uuid_after: "{{ test_insights_uuid }}"
+
+    - name: Check the insights UUID changed
+      assert:
+        that: test_insights_uuid_before != test_insights_uuid_after
+
     - name: Unregister insights
       include_role:
         name: linux-system-roles.rhc

--- a/tests/tests_register_unregister.yml
+++ b/tests/tests_register_unregister.yml
@@ -44,6 +44,43 @@
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
 
+    - name: Get rhsm UUID
+      include_tasks: tasks/get_rhsm_uuid.yml
+
+    - name: Rename the rhsm UUID to test_rhsm_uuid_before
+      set_fact:
+        test_rhsm_uuid_before: "{{ test_rhsm_uuid }}"
+
+    - name: Register (force)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          login:
+            username: "{{ lsr_rhc_test_data.reg_username }}"
+            password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_insights:
+          state: absent
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_state: reconnect
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+    - name: Get rhsm UUID
+      include_tasks: tasks/get_rhsm_uuid.yml
+
+    - name: Rename the rhsm UUID to test_rhsm_uuid_after
+      set_fact:
+        test_rhsm_uuid_after: "{{ test_rhsm_uuid }}"
+
+    - name: Check the rhsm UUID changed
+      assert:
+        that: test_rhsm_uuid_before.stdout != test_rhsm_uuid_after.stdout
+
     - name: Unregister
       include_role:
         name: linux-system-roles.rhc

--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -108,6 +108,58 @@
               state: absent
             rhc_release: "{{ lsr_rhc_test_data.release }}"
 
+        - name: Register (forced, without release)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_release: {"state":"absent"}
+
+        - name: Get set release
+          include_tasks: tasks/get_release.yml
+
+        - name: Check no release is set
+          assert:
+            that:
+              - test_release.stdout | length == 0
+
+        - name: Register (forced, with release)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_release: "{{ lsr_rhc_test_data.release }}"
+
+        - name: Get set release
+          include_tasks: tasks/get_release.yml
+
+        - name: Check wanted release is set
+          assert:
+            that:
+              - lsr_rhc_test_data.release == test_release.stdout
+
       always:
         - name: Unregister
           include_role:


### PR DESCRIPTION
Add an extra value to the `rhc_state` parameter to force the reconnection/registration of an already connected system, i.e. by disconnecting it first. When forcing the registration, some of the tasks/variables are used even if the system was previously connected (and thus its previous status does not matter).

In case we need to reconnect:
- avoid some checks on the status of subscription-manager or insights-client, as we will need to reconnect anyway, so unconditionally disconnect
- apply some of the logic/flows used for (not forced) connection

Make sure to test this:
- add helper scripts to get the system UUID from `subscription-manager`, and from `insights-client` (indirectly)
- extend `tests_register_unregister.yml`, and `tests_insights_client_register.yml` to get the rhsm/insights UUID after the connection, forcing a new connection, and checking that the UUID changed
- extend `tests_release.yml` to check that the release is properly changed also when forcing