### PR TITLE
tests: specify "rhc_baseurl" where needed

### DIFF
--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -34,6 +34,7 @@
           port: "{{ lsr_rhc_test_data.candlepin_port }}"
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
     - name: Register insights (noop)
       include_role:
@@ -51,6 +52,7 @@
           port: "{{ lsr_rhc_test_data.candlepin_port }}"
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
     - name: Get insights UUID
       include_tasks: tasks/get_insights_uuid.yml

--- a/tests/tests_proxy.yml
+++ b/tests/tests_proxy.yml
@@ -119,6 +119,7 @@
           port: "{{ lsr_rhc_test_data.candlepin_port }}"
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
         rhc_proxy:
           hostname: "{{ lsr_rhc_test_data.proxy_noauth_hostname }}"
           port: "{{ lsr_rhc_test_data.proxy_noauth_port }}"
@@ -276,6 +277,7 @@
           port: "{{ lsr_rhc_test_data.candlepin_port }}"
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
         rhc_proxy:
           hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
           port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
@@ -304,6 +306,7 @@
           port: "{{ lsr_rhc_test_data.candlepin_port }}"
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
         rhc_proxy: {"state":"absent"}
 
     - name: Unregister

--- a/tests/tests_register_unregister.yml
+++ b/tests/tests_register_unregister.yml
@@ -26,6 +26,7 @@
           port: "{{ lsr_rhc_test_data.candlepin_port }}"
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
     - name: Register (noop)
       include_role:
@@ -43,6 +44,7 @@
           port: "{{ lsr_rhc_test_data.candlepin_port }}"
           prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
     - name: Get rhsm UUID
       include_tasks: tasks/get_rhsm_uuid.yml

--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -33,6 +33,7 @@
               port: "{{ lsr_rhc_test_data.candlepin_port }}"
               prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_release: "{{ lsr_rhc_test_data.release }}"
 
         - name: Get set release
@@ -128,6 +129,7 @@
               port: "{{ lsr_rhc_test_data.candlepin_port }}"
               prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_release: {"state":"absent"}
 
         - name: Get set release
@@ -154,6 +156,7 @@
               port: "{{ lsr_rhc_test_data.candlepin_port }}"
               prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_release: "{{ lsr_rhc_test_data.release }}"
 
         - name: Get set release


### PR DESCRIPTION
The role now may perform package checks in some cases, and because of that it needs to make sure that the package manager has usable repositories. Hence, pass the baseurl configured (if any, hence the "omit") for the tests as "rhc_baseurl" parameter in all the "rhc" invocations that are supposed to work (i.e. not fail for expected failing parameters).