### PR TITLE
Implement rhc_environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ rhc_proxy:
 Use `{"state":"absent"}` to reset all the proxy configurations to empty
 (effectively disabling the proxy server).
 
+    rhc_environments: []
+
+The list of environments to which register to when connecting the system.
+
+*NB*: this only works when the system is being connected from an unconnected
+state -- it cannot change the environments of already connected systems.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 ---
 rhc_auth: {}
 rhc_baseurl: null
+rhc_environments: []
 rhc_insights:
   remediation: present
   state: present

--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -88,6 +88,9 @@
       {{ rhc_proxy.password }}
       {%- endif %}"
     force_register: "{{ rhc_state | d('present') == 'reconnect' }}"
+    environment: "{{ rhc_environments | join(',')
+      if (rhc_environments | length > 0
+          and rhc_state | d('present') != 'absent') else omit }}"
 
 - name: Configure subscribed system
   when:

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,9 @@ lsr_rhc_test_data:
   proxy_nonworking_port: invalid-port
   proxy_nonworking_username: "wrong-username"
   proxy_nonworking_password: "wrong-password"
+  envs_register:
+    - "Environment 1"
+  env_nonworking: "not-a-valid-environment"
 ```
 
 - `candlepin_host` & `candlepin_port` are the hostname & the port of Candlepin
@@ -60,6 +63,10 @@ lsr_rhc_test_data:
    - `proxy_nonworking_hostname`, `proxy_nonworking_port`,
      `proxy_nonworking_username` & `proxy_nonworking_password` are wrong details
      of proxy server configuration bits
+- `envs_register` is a list of working environments to use when registering a
+  system, and there must be at least one; if environments are not supported or
+  enabled in the Candlepin instance, this needs to be set to `null`
+- `env_nonworking` is an environment that does not exist
 
 To use this custom configuration, set the `LSR_RHC_TEST_DATA` environment
 variable to the full path of that file.

--- a/tests/tasks/list_environments.yml
+++ b/tests/tasks/list_environments.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Run subscription-manager environments --list-enabled
+  shell: |
+    set -euo pipefail
+    subscription-manager environments --list-enabled |
+    awk -F':' '/^Name/ {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}'
+  register: test_environments
+  changed_when: false

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -122,6 +122,25 @@
       loop:
         "{{ pools.json }}"
 
+    - name: Configure environments
+      when: environments | d(false)
+      block:
+        - name: Add environments
+          uri:
+            url: https://localhost:8443/candlepin/owners/admin/environments
+            method: POST
+            url_username: "admin"
+            url_password: "admin"
+            validate_certs: false
+            body_format: json
+            body:
+              name: "{{ item.name }}"
+              description: "{{ item.desc }}"
+              id: "{{ item.id }}"
+          loop:
+            - {name: "Environment 1", desc: "The environment 1", id: "envId1"}
+            - {name: "Environment 2", desc: "The environment 2", id: "envId2"}
+
     - name: Set variables
       set_fact:
         lsr_rhc_test_data:
@@ -151,6 +170,9 @@
           proxy_nonworking_port: 4000
           proxy_nonworking_username: "wrong-proxyuser"
           proxy_nonworking_password: "wrong-proxypassword"
+          envs_register:
+            - "Environment 2"
+          env_nonworking: "Ceci n'est pas une environment"
         cacheable: true
 
 - name: Check Candlepin works

--- a/tests/tests_environments.yml
+++ b/tests/tests_environments.yml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Basic repository enablement/disablement test
+  hosts: all
+  gather_facts: true
+  become: true
+  tags:
+    - tests::slow
+  tasks:
+    - name: Setup Candlepin
+      import_tasks: tasks/setup_candlepin.yml
+      vars:
+        environments: true
+
+    - name: Skip if no test environments are set
+      meta: end_play
+      when:
+        - >-
+          lsr_rhc_test_data.envs_register is none
+          or lsr_rhc_test_data.envs_register | d([]) | length == 0
+
+    - name: Try to register (wrong environment)
+      block:
+        - name: Register (wrong environment)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+            rhc_environments:
+              - "{{ lsr_rhc_test_data.env_nonworking }}"
+
+        - name: Unreachable task
+          fail:
+            msg: The above task must fail
+      rescue:
+        - name: Assert registration failed
+          assert:
+            that: ansible_failed_result.msg != 'The above task must fail'
+
+    - name: Test environments on registration
+      block:
+        - name: Register (with existing environments)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+            rhc_environments: "{{ lsr_rhc_test_data.envs_register }}"
+
+        # 'subscription-manager environments' has a '--list' option only
+        # in RHEL 8.6+ and greater (incl. RHEL 9+)
+        - name: Check the enabled environments
+          when:
+            - >-
+              ansible_distribution not in ["CentOS", "RedHat"]
+              or ansible_distribution_major_version | int >= 8
+          block:
+            - name: Get enabled environments
+              include_tasks: tasks/list_environments.yml
+
+            - name: Check environments to enable are enabled
+              assert:
+                that:
+                  - >-
+                    (lsr_rhc_test_data.envs_register | sort) ==
+                    (test_environments.stdout_lines | sort)
+
+      always:
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent


### PR DESCRIPTION
Add a parameter for configuring the environments to register to when connecting (and only in that case, due to different permissions needed to change the environments in already connected systems).

Make sure to test this:
- extend the test setup with variables related to environments
- add an helper script to get the list of set environments from subscription-manager
- improve the Candlepin deployment by adding a couple of test environments
- add a new test to verify that setting environments on connection works

Since enabling environments makes the environment selection mandatory, pass the configured environments to all the invocations of "rhc" that actually do connect successfully.