### PR TITLE
tests: copy Candlepin product certs in the right place

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -68,7 +68,7 @@
     - name: Copy product certificates
       copy:
         src: "/home/candlepin/devel/candlepin/generated_certs/{{ item }}.pem"
-        dest: "/etc/pki/product/{{ item }}.pem"
+        dest: "/etc/pki/product-default/{{ item }}.pem"
         remote_src: true
         mode: 0644
       loop:


### PR DESCRIPTION
The right place for the product certificates used for content is `/etc/pki/product-default`, not `/etc/pki/product` -- the latter just happens to work fine because it's used by subscription-manager for certificates downloaded from the repositories.

There is no functional behaviour in the tests.