### PR TITLE
tests: improve assertions for negative tests

### DIFF
--- a/tests/tests_proxy.yml
+++ b/tests/tests_proxy.yml
@@ -41,7 +41,7 @@
       rescue:
         - name: Assert registration failed
           assert:
-            that: true
+            that: ansible_failed_result.msg != 'The above task must fail'
 
     - name: Try to register (wrong host)
       block:
@@ -71,7 +71,7 @@
       rescue:
         - name: Assert registration failed
           assert:
-            that: true
+            that: ansible_failed_result.msg != 'The above task must fail'
 
     - name: Try to register (wrong port)
       block:
@@ -101,7 +101,7 @@
       rescue:
         - name: Assert registration failed
           assert:
-            that: true
+            that: ansible_failed_result.msg != 'The above task must fail'
 
     - name: Register (no authentication)
       include_role:
@@ -163,7 +163,7 @@
       rescue:
         - name: Assert registration failed
           assert:
-            that: true
+            that: ansible_failed_result.msg != 'The above task must fail'
 
     - name: Try to register (wrong username, wrong password)
       block:
@@ -195,7 +195,7 @@
       rescue:
         - name: Assert registration failed
           assert:
-            that: true
+            that: ansible_failed_result.msg != 'The above task must fail'
 
     - name: Try to register (wrong username)
       block:
@@ -227,7 +227,7 @@
       rescue:
         - name: Assert registration failed
           assert:
-            that: true
+            that: ansible_failed_result.msg != 'The above task must fail'
 
     - name: Try to register (wrong password)
       block:
@@ -259,7 +259,7 @@
       rescue:
         - name: Assert registration failed
           assert:
-            that: true
+            that: ansible_failed_result.msg != 'The above task must fail'
 
     - name: Register (authentication)
       include_role:

--- a/tests/tests_register_unregister.yml
+++ b/tests/tests_register_unregister.yml
@@ -34,7 +34,7 @@
       rescue:
         - name: Assert registration failed
           assert:
-            that: true
+            that: ansible_failed_result.msg != 'The above task must fail'
 
     - name: Register
       include_role:


### PR DESCRIPTION
In case we expect a task to fail, we check in the "rescue" part of a "block" that something actually failed; since the "block" has a "fail" task to force a failure in case the task did not fail, we want to check that the reason we get into "rescue" is not the "forced failure".

Hence, tighten the asserts to ignore the forced failure task. Suggested by Richard Megginson in
https://github.com/linux-system-roles/rhc/pull/48