### PR TITLE
tests: fix enforced squid authentication

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -110,7 +110,7 @@
           proxy_auth_hostname: localhost
           proxy_auth_port: 3130
           proxy_auth_username: "proxyuser"
-          proxy_auth_password: "proxyuser"
+          proxy_auth_password: "proxypass"
           proxy_nonworking_hostname: "wrongproxy"
           proxy_nonworking_port: 4000
           proxy_nonworking_username: "wrong-proxyuser"

--- a/tests/tasks/setup_squid.yml
+++ b/tests/tasks/setup_squid.yml
@@ -73,6 +73,18 @@
             regexp: "^http_port "
             line: "http_port {{ lsr_rhc_test_data.proxy_auth_port }}"
 
+        - name: Disable HTTP access allow
+          lineinfile:
+            path: /etc/squid/squid.conf
+            regexp: "^http_access allow (localhost|localnet)$"
+            state: absent
+
+        - name: Disable HTTP deny all
+          lineinfile:
+            path: /etc/squid/squid.conf
+            regexp: "^http_access deny all$"
+            state: absent
+
         - name: Insert auth config into configuration
           blockinfile:
             path: /etc/squid/squid.conf
@@ -80,6 +92,8 @@
             block: |
               auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwd
               auth_param basic realm squid realm
+              acl authenticated proxy_auth REQUIRED
+              http_access allow authenticated
             # yamllint enable rule:line-length
 
     - name: Restart squid


### PR DESCRIPTION
Tweak the squid configuration to properly enforce authentication:
- disable the http_access bits that allow any localhost/localnet clients
- require authentication to connect

Also, tweak the test password for the proxy to be "proxypass" rather than "proxyuser" (which is the authentication username).

This affected only tests_proxy when run using a self-deployed Candlepin & squid; both the role and the test already worked fine, as testing against external servers (especially properly configured proxy servers) showed.