### PR TITLE
Fix rhc_auth.activation_keys.keys

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -44,8 +44,8 @@
       if (rhc_state | d('present') == 'present'
            and __rhc_subman_identity.rc == 0)
       else (rhc_auth.login.password | d(omit)) }}"
-    activationkey: "{{ rhc_auth.activation_keys.keys | join(',')
-      if (rhc_auth.activation_keys.keys is defined) else omit }}"
+    activationkey: "{{ rhc_auth.activation_keys['keys'] | join(',')
+      if ('keys' in rhc_auth.activation_keys | d({})) else omit }}"
     org_id: "{{ rhc_organization | d(omit) }}"
     server_hostname: "{{ rhc_server.hostname | d(omit) }}"
     server_port: "{{ rhc_server.port | d(omit) }}"
@@ -53,7 +53,8 @@
     server_insecure: "{{ omit if (rhc_server.insecure | d(omit) == omit)
       else rhc_server.insecure | ternary('1', '0') }}"
     auto_attach: "{{ true
-      if (rhc_state | d('present') in ['present', 'reconnect']) else omit }}"
+      if (rhc_state | d('present') in ['present', 'reconnect']
+          and not 'keys' in rhc_auth.activation_keys | d({})) else omit }}"
     release: "{{ rhc_release
       if (rhc_state | d('present') != 'absent'
            and rhc_release != __rhc_state_absent)

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,9 @@ lsr_rhc_test_data:
   candlepin_insecure: 1
   reg_username: "username"
   reg_password: "password"
+  reg_activation_keys:
+    - "key1"
+    - "key2"
   reg_organization: "organization"
   baseurl: "https://base-url"
   repositories:
@@ -37,10 +40,11 @@ lsr_rhc_test_data:
 - `candlepin_prefix` is the path under which Candlepin listens to
 - `candlepin_insecure` specifies whether do not validate the Candlepin SSL
   certificate (needed usually in self-deployments)
-- `reg_username`, `reg_password` & `reg_organization` are the credentials
-  of the user to use in the vast majority of the registration tests;
-  `reg_organization` can be specified as `null` in case `reg_username` belongs
-  to only one organization
+- `reg_username`, `reg_password`, `reg_activation_keys` & `reg_organization`
+  are the credentials of the user to use in the vast majority of the
+  registration tests; `reg_organization` can be specified as `null` in case
+  `reg_username` belongs to only one organization, and only for tests in which
+  activation keys are not used
 - `baseurl` is the base URL for receiving content
 - `repositories` is a list of repositories to use in tests for content,
   and to assert for enablement/disablement; it has the same format of the

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -88,6 +88,34 @@
         remote_src: true
         mode: 0644
 
+    - name: Query for default_key activation key
+      uri:
+        url: https://localhost:8443/candlepin/owners/admin/activation_keys?name=default_key  # yamllint disable-line
+        method: GET
+        url_username: "admin"
+        url_password: "admin"
+        validate_certs: false
+      register: default_key
+
+    - name: Get pools for product 5050
+      uri:
+        url: https://localhost:8443/candlepin/owners/admin/pools?product=5050
+        method: GET
+        url_username: "admin"
+        url_password: "admin"
+        validate_certs: false
+      register: pools
+
+    - name: Add pools for product 5050 to default_key activation key
+      uri:
+        url: "https://localhost:8443/candlepin/activation_keys/{{ default_key.json[0].id }}/pools/{{ item.id }}"  # yamllint disable-line
+        method: POST
+        url_username: "admin"
+        url_password: "admin"
+        validate_certs: false
+      loop:
+        "{{ pools.json }}"
+
     - name: Set variables
       set_fact:
         lsr_rhc_test_data:
@@ -97,6 +125,8 @@
           candlepin_insecure: false
           reg_username: "admin"
           reg_password: "admin"
+          reg_activation_keys:
+            - "default_key"
           reg_invalid_username: "invalid-user"
           reg_invalid_password: "invalid-password"
           reg_organization: "admin"

--- a/tests/tests_register_unregister.yml
+++ b/tests/tests_register_unregister.yml
@@ -115,6 +115,29 @@
       vars:
         rhc_state: absent
 
+    - name: Register (using activation keys)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          activation_keys:
+            keys: "{{ lsr_rhc_test_data.reg_activation_keys }}"
+        rhc_insights:
+          state: absent
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+    - name: Unregister
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_state: absent
+
     - name: Unregister (noop)
       include_role:
         name: linux-system-roles.rhc


### PR DESCRIPTION
It seems that ".keys" for a dictionary is actually a reserved keyword, and thus it cannot be used; hence, use the array notation to look it up.

Also, auto-attach cannot be used when using activation keys, so do not enable it in that case.

Make sure to test this:
- extend the test data by adding all the pools for the "admin" user to the "default_key" (existing and with no pools), so auto-attach works
- add a simple test of registration with activation keys to tests_register_unregister