### PR TITLE
tests: ensure 'expect' is installed for Candlepin

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -41,6 +41,12 @@
         content: "candlepin ALL=(ALL) NOPASSWD: ALL\n"
         mode: 0440
 
+    - name: Install needed packages
+      package:
+        name:
+          - expect
+        state: present
+
     - name: Run Candlepin install
       block:
         - name: Include candlepin role


### PR DESCRIPTION
'expect' is currently needed by the Candlepin script that generates and signs the test packages, so make sure it is installed.

This fixes the generation of the test RPM packages on EL7.