### PR TITLE
tests: fixed mising rhc_state parameter in release tests

### DIFF
--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -131,6 +131,7 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_release: {"state":"absent"}
+            rhc_state: "reconnect"
 
         - name: Get set release
           include_tasks: tasks/get_release.yml
@@ -158,6 +159,7 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_release: "{{ lsr_rhc_test_data.release }}"
+            rhc_state: "reconnect"
 
         - name: Get set release
           include_tasks: tasks/get_release.yml

--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -131,7 +131,7 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_release: {"state":"absent"}
-            rhc_state: "reconnect"
+            rhc_state: reconnect
 
         - name: Get set release
           include_tasks: tasks/get_release.yml

--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -159,7 +159,7 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_release: "{{ lsr_rhc_test_data.release }}"
-            rhc_state: "reconnect"
+            rhc_state: reconnect
 
         - name: Get set release
           include_tasks: tasks/get_release.yml


### PR DESCRIPTION
	test release setting with force registration should have rhc_state: "reconnect" defined

Signed-off-by: Archana Pandey <arpandey@redhat.com>