### PR TITLE
Implement "rhc_insights.remediation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ Whether the system is connected to Insights; valid values are `present`
 (to ensure registration/connection), and `absent`.
 
 
+    rhc_insights:
+      remediation: present
+
+Whether the system is configured to run Insights remediation; valid values are
+`present` (to ensure remediation) and `absent`.
+
+
     rhc_proxy: {}
 
 The details of the proxy server to use for connecting:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 rhc_auth: {}
 rhc_baseurl: null
 rhc_insights:
+  remediation: present
   state: present
 rhc_organization: null
 rhc_proxy: {}

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -18,3 +18,27 @@
       or "NOT" in __rhc_insights_status.stdout
       or "unregistered" in __rhc_insights_status.stdout
   register: __rhc_insights_registration_result
+
+- name: Configure remediation
+  when: rhc_insights.remediation | d("present") == "present"
+  block:
+    - name: Ensure worker and ansible packages are installed
+      package:
+        name:
+          - rhc
+          - rhc-worker-playbook
+          - ansible-core
+        state: present
+
+    - name: Enable remediation
+      systemd:
+        enabled: true
+        state: started
+        name: rhcd
+
+- name: Disable remediation
+  systemd:
+    enabled: false
+    state: stopped
+    name: rhcd
+  when: rhc_insights.remediation | d("present") == "absent"

--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -27,6 +27,7 @@
             username: "{{ lsr_rhc_test_data.reg_username }}"
             password: "{{ lsr_rhc_test_data.reg_password }}"
         rhc_insights:
+          remediation: absent
           state: present
         rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
         rhc_server:
@@ -45,6 +46,7 @@
             username: "{{ lsr_rhc_test_data.reg_username }}"
             password: "{{ lsr_rhc_test_data.reg_password }}"
         rhc_insights:
+          remediation: absent
           state: present
         rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
         rhc_server:
@@ -69,6 +71,8 @@
           login:
             username: "{{ lsr_rhc_test_data.reg_username }}"
             password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_insights:
+          remediation: absent
         rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
         rhc_server:
           hostname: "{{ lsr_rhc_test_data.candlepin_host }}"

--- a/tests/tests_insights_remediation.yml
+++ b/tests/tests_insights_remediation.yml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Test for insights remediation enabled & disabled
+  hosts: all
+  gather_facts: true
+
+  tasks:
+    - name: Skip when running with embedded Candlepin
+      meta: end_play
+      when:
+        - lookup('env', 'LSR_RHC_TEST_DATA') | length == 0
+      delegate_to: 127.0.0.1
+      become: false
+
+    - name: Import test data
+      include_vars:
+        file: "{{ lookup('env', 'LSR_RHC_TEST_DATA') }}"
+      delegate_to: 127.0.0.1
+      become: false
+
+    - name: Register insights and enable remediation
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          login:
+            username: "{{ lsr_rhc_test_data.reg_username }}"
+            password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_insights:
+          remediation: present
+          state: present
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+    - name: Get service_facts
+      service_facts:
+
+    - name: Check remediation is enabled
+      assert:
+        that:
+          - "'rhcd.service' in ansible_facts.services"
+          - ansible_facts.services['rhcd.service'].status == 'enabled'
+
+    - name: Disable remediation
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_insights:
+          remediation: absent
+
+    - name: Get service_facts
+      service_facts:
+
+    - name: Check remediation is disabled
+      assert:
+        that:
+          - "'rhcd.service' in ansible_facts.services"
+          - ansible_facts.services['rhcd.service'].status == 'disabled'
+
+    - name: Disable remediation (noop)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_insights:
+          remediation: absent
+
+    - name: Unregister insights
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_state: absent


### PR DESCRIPTION
- Add a new parameter `rhc_insights.remediation` to enable insights remediation.  This depends on additional packages that need to be installed and to enable and start a service.
- Add a configuration test that enables and disables remediation.
