### PR TITLE
Revert "meta: temporarily add tests requirements for the role (#20)"

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,6 +1,3 @@
 ---
 collections:
-  - name: ansible.posix
   - name: community.general
-  - name: community.mysql
-  - name: community.postgresql


### PR DESCRIPTION
The test infra now supports tests/collection-requirements.yml; hence, revert the addition of the tests-only requirements from meta/collection-requirements.yml.

This reverts commit f311da4cdb1cf3b351307861bb7fcddd76a9de7e.