### PR TITLE
Implemented "rhc_insights.tags" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,29 @@ Whether the system is connected to Insights; valid values are `present`
 Whether the system is configured to run Insights remediation; valid values are
 `present` (to ensure remediation) and `absent`.
 
+    rhc_insights:
+      tags: {}
+
+A dictionary of tags that is added to the system record in Host Based Inventory (HBI).
+Used to search for hosts. This tags has keys and values. Values for each key can be any 
+data type. Posible values of `tags` parameter:
+- `tags` is `null` or an empty value (e.g: `{}`) does not change the tags file content.
+- `tags` is `{state: absent}` remove all the tags by removing the file.
+- `tags` is non-empty, create the file with the specified tags
+
+An example of the tags configured in the `insights-client` [documentation](https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/client_configuration_guide_for_red_hat_insights/con-insights-client-tagging-overview_insights-cg-adding-tags):
+
+```yaml
+rhc_insights:
+  tags:
+    group: _group-name-value_
+    location: _location-name-value_
+    description:
+      - RHEL8
+      - SAP
+    key 4: value
+```
+
 
     rhc_proxy: {}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ rhc_environments: []
 rhc_insights:
   remediation: present
   state: present
+  tags: {}
 rhc_organization: null
 rhc_proxy: {}
 rhc_release: null

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -10,6 +10,25 @@
   when:
     - rhc_state | d("present") != "reconnect"
 
+- name: Add insights tags
+  copy:
+    dest: /etc/insights-client/tags.yml
+    content: "{{ rhc_insights.tags | to_nice_yaml(indent=2) }}"
+    mode: '0644'
+  register: __insights_tags_added
+  when:
+    - rhc_insights.tags is defined
+    - rhc_insights.tags != __rhc_state_absent
+    - rhc_insights.tags | d({}) | length > 0
+
+- name: Delete insights tags
+  file:
+    state: absent
+    path: /etc/insights-client/tags.yml
+  register: __insights_tags_removed
+  when:
+    - rhc_insights.tags | d(None) == __rhc_state_absent
+
 - name: Register insights-client
   command: insights-client --register
   when:
@@ -18,6 +37,16 @@
       or "NOT" in __rhc_insights_status.stdout
       or "unregistered" in __rhc_insights_status.stdout
   register: __rhc_insights_registration_result
+
+- name: Do the collection if insights-client was registered
+  command: insights-client
+  when:
+    - >-
+      "This host is registered" in __rhc_insights_status.stdout
+      or "Registered" in __rhc_insights_status.stdout
+    - >-
+      __insights_tags_added is changed
+      or __insights_tags_removed is changed
 
 - name: Configure remediation
   when: rhc_insights.remediation | d("present") == "present"

--- a/tests/tasks/get_insights_tags.yml
+++ b/tests/tasks/get_insights_tags.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Get state of insights tag file
+  stat:
+    path: /etc/insights-client/tags.yml
+  register: test_insights_tags

--- a/tests/tests_insights_tags.yml
+++ b/tests/tests_insights_tags.yml
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Test for insights tags
+  hosts: all
+  gather_facts: true
+
+  tasks:
+    - name: Skip when running with embedded Candlepin
+      meta: end_play
+      when:
+        - lookup('env', 'LSR_RHC_TEST_DATA') | length == 0
+      delegate_to: 127.0.0.1
+      become: false
+
+    - name: Import test data
+      include_vars:
+        file: "{{ lookup('env', 'LSR_RHC_TEST_DATA') }}"
+      delegate_to: 127.0.0.1
+      become: false
+
+    - name: Configure tags and register insights
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          login:
+            username: "{{ lsr_rhc_test_data.reg_username }}"
+            password: "{{ lsr_rhc_test_data.reg_password }}"
+        rhc_insights:
+          state: present
+          tags:
+            group: ansible
+            activity: test
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+    - name: Get state of insights tags.yml file
+      include_tasks: get_insights_tags.yml
+
+    - name: Rename the tags to test_insights_tags_modified
+      set_fact:
+        test_insights_tags_new: "{{ test_insights_tags }}"
+
+    - name: Check if tags.yml file exists and its size is > 0
+      assert:
+        that: test_insights_tags_new.stat.size > 0
+
+    - name: Change tags
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_insights:
+          tags:
+            group:
+              - ansible
+              - rhc
+
+    - name: Get state of insights tags.yml file
+      include_tasks: get_insights_tags.yml
+
+    - name: Rename the tags to test_insights_tags_modified
+      set_fact:
+        test_insights_tags_modified: "{{ test_insights_tags.stat.size }}"
+
+    - name: Check if tags.yml file exists and its size has changed
+      assert:
+        that:
+          - test_insights_tags_new.stat.size != test_insights_tags_modified
+
+    - name: Do nothing
+      include_role:
+        name: linux-system-roles.rhc
+
+    - name: Get state of insights tags.yml file
+      include_tasks: get_insights_tags.yml
+
+    - name: Check if tags.yml file exists and its size is the same
+      assert:
+        that:
+          - test_insights_tags.stat.size == test_insights_tags_modified
+
+    - name: Remove all tags
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_insights:
+          tags:
+            state: absent
+
+    - name: Get state of insights tags.yml file
+      include_tasks: get_insights_tags.yml
+
+    - name: Check that insights tags.yml file does not exists
+      assert:
+        that: test_insights_tags is undefined
+
+    - name: Unregister
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_state: absent


### PR DESCRIPTION
Add a new parameter to configure insights tags that will be added to the system record in HBI.

The syntax of this parameter is a dictionary, and the value for each key can be any data type.

The role will try to configure the tags if this parameter is present. If it is not present the tags will remain in the same status.

Test added that verifies:
- Add and delete tags
- Remove all tags
- Do not modify tags if the parameter is missing.
