### PR TITLE
meta: stop supporting EL7

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,6 @@ galaxy_info:
         - all
     - name: EL
       versions:
-        - "7"
         - "8"
         - "9"
 


### PR DESCRIPTION
After internal discussions, we decided to not support EL7 due to where it is in its lifecycle.