### PR TITLE
Improve tests for insights tags

### DIFF
--- a/tests/tests_insights_tags.yml
+++ b/tests/tests_insights_tags.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Test for insights tags
+- name: Basic test for insights tags
   hosts: all
   gather_facts: true
 
@@ -18,89 +18,95 @@
       delegate_to: 127.0.0.1
       become: false
 
-    - name: Configure tags and register insights
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          state: present
-          tags:
-            group: ansible
-            activity: test
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+    - name: Test insights tags
+      block:
+        - name: Configure tags and register insights
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              remediation: absent
+              state: present
+              tags:
+                group: ansible
+                activity: test
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
-    - name: Get state of insights tags.yml file
-      include_tasks: get_insights_tags.yml
+        - name: Get state of insights tags.yml file
+          include_tasks: get_insights_tags.yml
 
-    - name: Rename the tags to test_insights_tags_modified
-      set_fact:
-        test_insights_tags_new: "{{ test_insights_tags }}"
+        - name: Rename the tags to test_insights_tags_modified
+          set_fact:
+            test_insights_tags_new: "{{ test_insights_tags }}"
 
-    - name: Check if tags.yml file exists and its size is > 0
-      assert:
-        that: test_insights_tags_new.stat.size > 0
+        - name: Check if tags.yml file exists and its size is > 0
+          assert:
+            that: test_insights_tags_new.stat.size > 0
 
-    - name: Change tags
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_insights:
-          tags:
-            group:
-              - ansible
-              - rhc
+        - name: Change tags
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_insights:
+              remediation: absent
+              tags:
+                group:
+                  - ansible
+                  - rhc
 
-    - name: Get state of insights tags.yml file
-      include_tasks: get_insights_tags.yml
+        - name: Get state of insights tags.yml file
+          include_tasks: get_insights_tags.yml
 
-    - name: Rename the tags to test_insights_tags_modified
-      set_fact:
-        test_insights_tags_modified: "{{ test_insights_tags.stat.size }}"
+        - name: Rename the tags to test_insights_tags_modified
+          set_fact:
+            test_insights_tags_modified: "{{ test_insights_tags.stat.size }}"
 
-    - name: Check if tags.yml file exists and its size has changed
-      assert:
-        that:
-          - test_insights_tags_new.stat.size != test_insights_tags_modified
+        - name: Check if tags.yml file exists and its size has changed
+          assert:
+            that:
+              - test_insights_tags_new.stat.size != test_insights_tags_modified
 
-    - name: Do nothing
-      include_role:
-        name: linux-system-roles.rhc
+        - name: Do nothing
+          include_role:
+            name: linux-system-roles.rhc
 
-    - name: Get state of insights tags.yml file
-      include_tasks: get_insights_tags.yml
+        - name: Get state of insights tags.yml file
+          include_tasks: get_insights_tags.yml
 
-    - name: Check if tags.yml file exists and its size is the same
-      assert:
-        that:
-          - test_insights_tags.stat.size == test_insights_tags_modified
+        - name: Check if tags.yml file exists and its size is the same
+          assert:
+            that:
+              - test_insights_tags.stat.size == test_insights_tags_modified
 
-    - name: Remove all tags
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_insights:
-          tags:
-            state: absent
+        - name: Remove all tags
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_insights:
+              remediation: absent
+              tags:
+                state: absent
 
-    - name: Get state of insights tags.yml file
-      include_tasks: get_insights_tags.yml
+        - name: Get state of insights tags.yml file
+          include_tasks: get_insights_tags.yml
 
-    - name: Check that insights tags.yml file does not exists
-      assert:
-        that: test_insights_tags is undefined
+        - name: Check that insights tags.yml file does not exists
+          assert:
+            that: test_insights_tags is undefined
 
-    - name: Unregister
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
+      always:
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent


### PR DESCRIPTION
Added a block and always section to unregister the system in case the test fails.

Disable remediation from the playbook to reduce the tasks done.
