### PR TITLE
Fix rhc_insights.remediation when absent

### DIFF
--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -77,4 +77,6 @@
     enabled: false
     state: stopped
     name: rhcd
-  when: rhc_insights.remediation | d("present") == "absent"
+  when:
+    - rhc_insights.remediation | d("present") == "absent"
+    - '"rhc" in ansible_facts.packages'

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -6,10 +6,11 @@
   when: not ansible_facts.keys() | list |
     intersect(__rhc_required_facts) == __rhc_required_facts
 
-- name: Check if insights-client is installed
+- name: Check if insights-packages are installed
   package_facts:
   when:
     - ansible_distribution == "RedHat"
     - >-
       rhc_insights.state | d("present") == "absent"
       or rhc_state | d("present") in ["absent", "reconnect"]
+      or rhc_insights.remediation | d("present") == "absent"

--- a/tests/tests_insights_tags.yml
+++ b/tests/tests_insights_tags.yml
@@ -43,7 +43,7 @@
             rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
         - name: Get state of insights tags.yml file
-          include_tasks: get_insights_tags.yml
+          include_tasks: tasks/get_insights_tags.yml
 
         - name: Rename the tags to test_insights_tags_modified
           set_fact:
@@ -65,7 +65,7 @@
                   - rhc
 
         - name: Get state of insights tags.yml file
-          include_tasks: get_insights_tags.yml
+          include_tasks: tasks/get_insights_tags.yml
 
         - name: Rename the tags to test_insights_tags_modified
           set_fact:
@@ -79,9 +79,12 @@
         - name: Do nothing
           include_role:
             name: linux-system-roles.rhc
+          vars:
+            rhc_insights:
+              remediation: absent
 
         - name: Get state of insights tags.yml file
-          include_tasks: get_insights_tags.yml
+          include_tasks: tasks/get_insights_tags.yml
 
         - name: Check if tags.yml file exists and its size is the same
           assert:
@@ -98,7 +101,7 @@
                 state: absent
 
         - name: Get state of insights tags.yml file
-          include_tasks: get_insights_tags.yml
+          include_tasks: tasks/get_insights_tags.yml
 
         - name: Check that insights tags.yml file does not exists
           assert:


### PR DESCRIPTION
This tasks needs to check if the package is installed in the system before trying to disable it via systemd.

Added rhc_insights.remediation absent to one task of tags test that was missed to configure.
