### PR TITLE
Added vars for registration to the tests

### DIFF
--- a/tests/tests_insights_autoupdate.yml
+++ b/tests/tests_insights_autoupdate.yml
@@ -26,10 +26,21 @@
             name: linux-system-roles.rhc
             public: true
           vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_insights:
               autoupdate: true
               remediation: absent
               state: present
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
         - name: Check that auto_update is true in config file
           command:


### PR DESCRIPTION
Autoupdate test lacked of vars to perform the registration. This commit adds the variables.