### PR TITLE
Version 1.1.0 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 Changelog
 =========
 
+[1.1.0] - 2023-02-15
+--------------------
+
+### New Features
+
+- Implement "rhc_state: reconnect" (#43)
+- Implement "rhc_insights.remediation"
+- Implement rhc_environments (#48)
+- rhc_repository: setting default state of repo to enabled (#65)
+- Implemented "rhc_insights.tags" parameter
+- meta: stop supporting EL7 (#66)
+- Added "rhc_insights.autoupdate" parameter (#67)
+
+### Bug Fixes
+
+- Fix rhc_auth.activation_keys.keys (#54)
+- Fix rhc_insights.remediation when absent (#70)
+
+### Other Changes
+
+- Add check for non-inclusive language
+- ansible-lint 6.x fixes
+
 [1.0.0] - 2022-12-15
 --------------------
 


### PR DESCRIPTION
[1.1.0] - 2023-02-15
--------------------

- Implement "rhc_state: reconnect" (#43)
- Implement "rhc_insights.remediation"
- Implement rhc_environments (#48)
- rhc_repository: setting default state of repo to enabled (#65)
- Implemented "rhc_insights.tags" parameter
- meta: stop supporting EL7 (#66)
- Added "rhc_insights.autoupdate" parameter (#67)

- Fix rhc_auth.activation_keys.keys (#54)
- Fix rhc_insights.remediation when absent (#70)

- Add check for non-inclusive language
- ansible-lint 6.x fixes

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
