### PR TITLE
workaround insights-client issue with /usr/bin/python

### DIFF
--- a/tasks/check-insights-status.yml
+++ b/tasks/check-insights-status.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 - name: Call insights status
-  command: insights-client --status
+  shell: insights-client --status & wait
   changed_when: false
   register: __rhc_insights_status
   failed_when: __rhc_insights_status.rc not in [0,1]

--- a/tasks/insights-client-unregistration.yml
+++ b/tasks/insights-client-unregistration.yml
@@ -4,7 +4,7 @@
   include_tasks: check-insights-status.yml
 
 - name: Unregister insights-client
-  command: insights-client --unregister
+  shell: insights-client --unregister & wait
   when:
     - >-
       "This host is registered" in __rhc_insights_status.stdout

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -37,7 +37,7 @@
     line: auto_update={{ rhc_insights.autoupdate | d(true) | bool }}
 
 - name: Register insights-client
-  command: insights-client --register
+  shell: insights-client --register & wait
   when:
     - >-
       rhc_state | d("present") == "reconnect"
@@ -46,7 +46,7 @@
   register: __rhc_insights_registration_result
 
 - name: Do the collection if insights-client was registered
-  command: insights-client
+  shell: insights-client & wait
   when:
     - >-
       "This host is registered" in __rhc_insights_status.stdout


### PR DESCRIPTION
insights-client does not work properly when it is spawned from
/usr/bin/python, but it does work when spawned from /usr/bin/python3,
even if they are symlinks to each other i.e. the same binary.
Not sure why this is, but the workaround is to start
insights-client in the background and `wait` for it.
