### PR TITLE
tests: do not deploy Candlepin in tests_release

### DIFF
--- a/tests/tests_release.yml
+++ b/tests/tests_release.yml
@@ -7,13 +7,18 @@
   tags:
     - tests::slow
   tasks:
-    - name: Setup Candlepin
-      import_tasks: tasks/setup_candlepin.yml
+    # A local Candlepin deployment has no concept of "releases",
+    # so only setup the test data.
+    - name: Setup test data
+      import_tasks: tasks/setup_test_data.yml
 
     - name: Skip if no test release is set
       meta: end_play
       when:
         - lsr_rhc_test_data.release | d(none) is none
+
+    - name: Check Candlepin works
+      import_tasks: tasks/check_candlepin.yml
 
     - name: Test release
       block:


### PR DESCRIPTION
A local Candlepin deployment has no concept of "releases", so deploying it to unconditionally end the test is suboptimal.

Make use of the new helper tasks for the tests:
- only setup the test data first, so we get the configured release version for the test
- keep skipping the test if there is no configured release: this way, even an external Candlepin configuration may still skip the test
- ensure that the configured Candlepin works: `setup_candlepin.yml` does it automatically, so we need to manually use `check_candlepin.yml` now

The only behaviour change is that this test will end much faster when using the local Candlepin deployment (i.e. the default setup).