### PR TITLE
tests: refactor Insights setup

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -37,6 +37,7 @@ lsr_rhc_test_data:
   envs_register:
     - "Environment 1"
   env_nonworking: "not-a-valid-environment"
+  insights: false
 ```
 
 - `candlepin_host` & `candlepin_port` are the hostname & the port of Candlepin
@@ -67,6 +68,8 @@ lsr_rhc_test_data:
   system, and there must be at least one; if environments are not supported or
   enabled in the Candlepin instance, this needs to be set to `null`
 - `env_nonworking` is an environment that does not exist
+- `insights` specifies whether Insights works with the specified
+  `candlepin_host`
 
 To use this custom configuration, set the `LSR_RHC_TEST_DATA` environment
 variable to the full path of that file.

--- a/tests/files/candlepin_data.yml
+++ b/tests/files/candlepin_data.yml
@@ -30,3 +30,4 @@ lsr_rhc_test_data:
   envs_register:
     - "Environment 2"
   env_nonworking: "Ceci n'est pas une environment"
+  insights: false  # no Insights with own Candlepin deployment

--- a/tests/tasks/setup_insights.yml
+++ b/tests/tasks/setup_insights.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+---
+# A local Candlepin deployment has no Insights support,
+# so only setup the test data.
+- name: Setup test data
+  import_tasks: tasks/setup_test_data.yml
+
+- name: Skip if there is no Insights support
+  meta: end_play
+  when:
+    - not lsr_rhc_test_data.insights
+
+- name: Check Candlepin works
+  import_tasks: tasks/check_candlepin.yml

--- a/tests/tests_insights_autoupdate.yml
+++ b/tests/tests_insights_autoupdate.yml
@@ -6,18 +6,8 @@
   become: true
 
   tasks:
-    - name: Skip when running with embedded Candlepin
-      meta: end_play
-      when:
-        - lookup('env', 'LSR_RHC_TEST_DATA') | length == 0
-      delegate_to: 127.0.0.1
-      become: false
-
-    - name: Import test data
-      include_vars:
-        file: "{{ lookup('env', 'LSR_RHC_TEST_DATA') }}"
-      delegate_to: 127.0.0.1
-      become: false
+    - name: Setup Insights
+      import_tasks: tasks/setup_insights.yml
 
     - name: Test autoupdate
       block:

--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -5,18 +5,8 @@
   gather_facts: true
 
   tasks:
-    - name: Skip when running with embedded Candlepin
-      meta: end_play
-      when:
-        - lookup('env', 'LSR_RHC_TEST_DATA') | length == 0
-      delegate_to: 127.0.0.1
-      become: false
-
-    - name: Import test data
-      include_vars:
-        file: "{{ lookup('env', 'LSR_RHC_TEST_DATA') }}"
-      delegate_to: 127.0.0.1
-      become: false
+    - name: Setup Insights
+      import_tasks: tasks/setup_insights.yml
 
     - name: Register insights
       include_role:

--- a/tests/tests_insights_remediation.yml
+++ b/tests/tests_insights_remediation.yml
@@ -5,18 +5,8 @@
   gather_facts: true
 
   tasks:
-    - name: Skip when running with embedded Candlepin
-      meta: end_play
-      when:
-        - lookup('env', 'LSR_RHC_TEST_DATA') | length == 0
-      delegate_to: 127.0.0.1
-      become: false
-
-    - name: Import test data
-      include_vars:
-        file: "{{ lookup('env', 'LSR_RHC_TEST_DATA') }}"
-      delegate_to: 127.0.0.1
-      become: false
+    - name: Setup Insights
+      import_tasks: tasks/setup_insights.yml
 
     - name: Register insights and enable remediation
       include_role:

--- a/tests/tests_insights_tags.yml
+++ b/tests/tests_insights_tags.yml
@@ -5,18 +5,8 @@
   gather_facts: true
 
   tasks:
-    - name: Skip when running with embedded Candlepin
-      meta: end_play
-      when:
-        - lookup('env', 'LSR_RHC_TEST_DATA') | length == 0
-      delegate_to: 127.0.0.1
-      become: false
-
-    - name: Import test data
-      include_vars:
-        file: "{{ lookup('env', 'LSR_RHC_TEST_DATA') }}"
-      delegate_to: 127.0.0.1
-      become: false
+    - name: Setup Insights
+      import_tasks: tasks/setup_insights.yml
 
     - name: Test insights tags
       block:


### PR DESCRIPTION
Currently, the Insights-related tests assume they can work (as in, there is Insights support) when using an external test data configuration; this may not be true, e.g. when configuring to use a self-deployed Candlepin. Also, they all duplicate the logic for importing the test data.

Improve the situation a bit:
- add a `insights` boolean value for the test data to determine whether there is support for Insights; set it to false for the own Candlepin deployment
- create an helper `setup_insights.yml` to contain all the needed logic for setting up a test that uses Insights:
  - only the test data is set up, as an own Candlepin does not support Insights
  - end the play execution if the test data says there is no Insights support
  - check that Candlepin works (it's needed in any case)
- use the new `setup_insights.yml` in all the Insights-related tests.