### PR TITLE
tests: updated insights unregister test to use rhc_insights instead r…

### DIFF
--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -87,9 +87,17 @@
       include_role:
         name: linux-system-roles.rhc
       vars:
-        rhc_state: absent
+        rhc_insights:
+          state: absent
 
     - name: Unregister insights (noop)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_insights:
+          state: absent
+
+    - name: Unregister System
       include_role:
         name: linux-system-roles.rhc
       vars:


### PR DESCRIPTION
…hc_state role variable

It appears that current insights unregister test is not validating rhc_insights variable, I have modified the test so that it can disconnect insights using-
rhc_insights:
  state: absent