### PR TITLE
tests: pin Candlepin version to latest before Java 17

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -50,6 +50,7 @@
             cp_configure_mariadb: false
             cp_configure_ruby: false
             cp_deploy_args: "-g -a -f -t -r"
+            cp_git_ref: 9263a30b1612a22ec00ae05bd7d9ed6e0cdedbaf
 
     - name: Enable tomcat
       service:


### PR DESCRIPTION
The current way of deploying Candlepin uses an Ansible role that is no more used/supported by the Candlepin project, and thus it is rotting; the recent switch of Candlepin from Java 11 to Java 17 broke with the unmaintained role.

Thus, as very short-term workaround, pin the version of Candlepin to deploy to the commit before the switch to Java 17.