### PR TITLE
Temporarily pin down community.general collection

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: community.general
+    version: "<6.5.0"

--- a/tests/collection-requirements.yml
+++ b/tests/collection-requirements.yml
@@ -2,6 +2,7 @@
 collections:
   - name: ansible.posix
   - name: community.general
+    version: "<6.5.0"
   - name: community.mysql
   - name: community.postgresql
   - name: fedora.linux_system_roles


### PR DESCRIPTION
There are a couple of bugs in the `redhat_subscription` module shipped with the community.general 6.5.0 collection, plus it hits old versions of subscription-manager in Fedora.

As a short-gap measure to keep things working, pin down the version of community.general to anything lower than 6.5.0.