### PR TITLE
Fix minor ansible-lint issues

### DIFF
--- a/tasks/insights-client-unregistration.yml
+++ b/tasks/insights-client-unregistration.yml
@@ -10,3 +10,4 @@
       "This host is registered" in __rhc_insights_status.stdout
       or "Registered" in __rhc_insights_status.stdout
   register: __rhc_insights_unregister_result
+  changed_when: true

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -44,6 +44,7 @@
       or "NOT" in __rhc_insights_status.stdout
       or "unregistered" in __rhc_insights_status.stdout
   register: __rhc_insights_registration_result
+  changed_when: true
 
 - name: Do the collection if insights-client was registered
   shell: insights-client & wait
@@ -54,6 +55,7 @@
     - >-
       __insights_tags_added is changed
       or __insights_tags_removed is changed
+  changed_when: true
 
 - name: Configure remediation
   when: rhc_insights.remediation | d("present") == "present"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,11 @@
 - name: Handle insights unregistration
   include_tasks: insights-client-unregistration.yml
   when:
-  - ansible_distribution == "RedHat"
-  - >-
-    rhc_insights.state | d("present") == "absent"
-    or rhc_state | d("present") in ["absent", "reconnect"]
-  - '"insights-client" in ansible_facts.packages'
+    - ansible_distribution == "RedHat"
+    - >-
+      rhc_insights.state | d("present") == "absent"
+      or rhc_state | d("present") in ["absent", "reconnect"]
+    - '"insights-client" in ansible_facts.packages'
 
 - name: Handle system subscription
   include_tasks: subscription-manager.yml
@@ -18,6 +18,6 @@
 - name: Handle insights registration
   include_tasks: insights-client.yml
   when:
-  - ansible_distribution == "RedHat"
-  - rhc_insights.state | d("present") == "present"
-  - rhc_state | d("present") in ["present", "reconnect"]
+    - ansible_distribution == "RedHat"
+    - rhc_insights.state | d("present") == "present"
+    - rhc_state | d("present") in ["present", "reconnect"]


### PR DESCRIPTION
- mark tasks that run `insights-client` as `changed_when=true`: this is done because, when they run, they will change things in the system
- fix indentation of conditions in a couple of `when` blocks