### PR TITLE
chore(meta): stop pinning community.general collection

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: community.general
-    version: ">=6.2.0,<6.5.0"
+    version: ">=6.2.0"


### PR DESCRIPTION
The issues in the `redhat_subscription` module shipped in the `community.general` collection were fixed in version 6.6.0, so it should not have regressions now.

Hence, stop pinning the `community.general` collection.

This reverts commit 26c0f43571306938de8be5571f9a7ec6512a7bb6.