### PR TITLE
Do not pass fake creds when activation keys are specified

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -38,11 +38,13 @@
       else rhc_state | d('present') }}"
     username: "{{ __rhc_fake_credential
       if (rhc_state | d('present') == 'present'
-           and __rhc_subman_identity.rc == 0)
+           and __rhc_subman_identity.rc == 0
+           and 'activation_keys' not in rhc_auth)
       else (rhc_auth.login.username | d(omit)) }}"
     password: "{{ __rhc_fake_credential
       if (rhc_state | d('present') == 'present'
-           and __rhc_subman_identity.rc == 0)
+           and __rhc_subman_identity.rc == 0
+           and 'activation_keys' not in rhc_auth)
       else (rhc_auth.login.password | d(omit)) }}"
     activationkey: "{{ rhc_auth.activation_keys['keys'] | join(',')
       if ('keys' in rhc_auth.activation_keys | d({})) else omit }}"

--- a/tests/tests_register_unregister.yml
+++ b/tests/tests_register_unregister.yml
@@ -158,6 +158,23 @@
           insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
         rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
+    - name: Register (using activation keys, noop)
+      include_role:
+        name: linux-system-roles.rhc
+      vars:
+        rhc_auth:
+          activation_keys:
+            keys: "{{ lsr_rhc_test_data.reg_activation_keys }}"
+        rhc_insights:
+          state: absent
+        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+        rhc_server:
+          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+          port: "{{ lsr_rhc_test_data.candlepin_port }}"
+          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
     - name: Unregister
       include_role:
         name: linux-system-roles.rhc


### PR DESCRIPTION
In case rhc_auth.activation_keys is specified (i.e. activation keys as credentials are used), then do not pass the fake username/password credentials to redhat_subscription, no matter the registration status; the redhat_subscription module rejects more than one credential type at the same time. This fixes specifying rhc_auth.activation_keys on an already registered system.

Check this case by duplicating the existing task for registration using activation keys in tests_register_unregister.yml, which now should pass (as noop) rather than failing.

Fixes #90