### PR TITLE
Consistent contributing.md for all roles - allow role specific contributing.md section

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,24 @@
+Contributing to the Rhc Linux System Role
+=============================================
+
+Where to start
+--------------
+
+The first place to go is [Contribute](https://linux-system-roles.github.io/contribute.html).
+This has all of the common information that all role developers need:
+* Role structure and layout
+* Development tools - How to run tests and checks
+* Ansible recommended practices
+* Basic git and github information
+* How to create git commits and submit pull requests
+
+- **Bugs and needed implementations** are listed on [Github
+  Issues](https://github.com/linux-system-roles/rhc/issues). Issues labeled with
+[**help
+wanted**](https://github.com/linux-system-roles/rhc/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+are likely to be suitable for new contributors!
+
+- **Code** is managed on
+  [Github](https://github.com/linux-system-roles/rhc), using [Pull
+Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
+


### PR DESCRIPTION
Provide a single, consistent contributing.md for all roles.  This mostly links to
and summarizes https://linux-system-roles.github.io/contribute.html

Allow for a role specific section which typically has information about
role particulars, role debugging tips, etc.

See https://github.com/linux-system-roles/.github/pull/19

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
