### PR TITLE
docs: Consistent contributing.md for all roles - allow role specific contributing.md section

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,5 +1,5 @@
-Contributing to the Rhc Linux System Role
-=============================================
+Contributing to the rhc Linux System Role
+=========================================
 
 Where to start
 --------------


### PR DESCRIPTION
Provide a single, consistent contributing.md for all roles.  This mostly links to
and summarizes https://linux-system-roles.github.io/contribute.html

Allow for a role specific section which typically has information about
role particulars, role debugging tips, etc.

Fix several markdown consistency issues, other issues found by markdownlint
Use https://www.markdownguide.org/basic-syntax#alternate-syntax style for
headings, using `### heading3`, `#### heading4`, etc. for lower level
headings.

See https://github.com/linux-system-roles/.github/pull/19

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
