### PR TITLE
fix: fix filename with insights-client tags

### DIFF
--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -12,7 +12,7 @@
 
 - name: Add insights tags
   copy:
-    dest: /etc/insights-client/tags.yml
+    dest: "{{ __rhc_insights_tags }}"
     content: "{{ rhc_insights.tags | to_nice_yaml(indent=2) }}"
     mode: '0644'
   register: __insights_tags_added
@@ -24,7 +24,7 @@
 - name: Delete insights tags
   file:
     state: absent
-    path: /etc/insights-client/tags.yml
+    path: "{{ __rhc_insights_tags }}"
   register: __insights_tags_removed
   when:
     - rhc_insights.tags | d(None) == __rhc_state_absent

--- a/tests/tasks/get_insights_tags.yml
+++ b/tests/tasks/get_insights_tags.yml
@@ -2,5 +2,5 @@
 ---
 - name: Get state of insights tag file
   stat:
-    path: /etc/insights-client/tags.yml
+    path: "{{ __rhc_insights_tags }}"
   register: test_tags

--- a/tests/tests_insights_tags.yml
+++ b/tests/tests_insights_tags.yml
@@ -13,6 +13,7 @@
         - name: Configure tags and register insights
           include_role:
             name: linux-system-roles.rhc
+            public: true
           vars:
             rhc_auth:
               login:
@@ -32,14 +33,14 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
-        - name: Get state of insights tags.yml file
+        - name: Get state of insights tags.yaml file
           include_tasks: tasks/get_insights_tags.yml
 
         - name: Rename the tags to test_tags_modified
           set_fact:
             test_tags_new: "{{ test_tags }}"
 
-        - name: Check if tags.yml file exists and its size is > 0
+        - name: Check if tags.yaml file exists and its size is > 0
           assert:
             that: test_tags_new.stat.size > 0
 
@@ -54,14 +55,14 @@
                   - ansible
                   - rhc
 
-        - name: Get state of insights tags.yml file
+        - name: Get state of insights tags.yaml file
           include_tasks: tasks/get_insights_tags.yml
 
         - name: Rename the tags to test_tags_chg
           set_fact:
             test_tags_chg: "{{ test_tags }}"
 
-        - name: Check if tags.yml file exists and its size has changed
+        - name: Check if tags.yaml file exists and its size has changed
           assert:
             that:
               - test_tags_new.stat.size != test_tags_chg.stat.size
@@ -73,10 +74,10 @@
             rhc_insights:
               remediation: absent
 
-        - name: Get state of insights tags.yml file
+        - name: Get state of insights tags.yaml file
           include_tasks: tasks/get_insights_tags.yml
 
-        - name: Check if tags.yml file exists and its size is the same
+        - name: Check if tags.yaml file exists and its size is the same
           assert:
             that:
               - test_tags.stat.size == test_tags_chg.stat.size
@@ -90,10 +91,10 @@
               tags:
                 state: absent
 
-        - name: Get state of insights tags.yml file
+        - name: Get state of insights tags.yaml file
           include_tasks: tasks/get_insights_tags.yml
 
-        - name: Check that insights tags.yml file does not exists
+        - name: Check that insights tags.yaml file does not exists
           assert:
             that: not test_tags.stat.exists
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -29,3 +29,5 @@ __rhc_fake_credential: "this-is-not-a-credential!"
 __rhc_empty_string: ""
 
 __rhc_insights_conf: "/etc/insights-client/insights-client.conf"
+
+__rhc_insights_tags: "/etc/insights-client/tags.yaml"


### PR DESCRIPTION
The file with the tags of insights-client is
`/etc/insights-client/tags.yaml`, not `tags.yml`.

To ease the situation a bit, move the full path to a role variable.

Reported-by: Benjamin Blasco <bblasco@redhat.com>