### PR TITLE
build: require community.general 6.2.0

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: community.general
-    version: "<6.5.0"
+    version: ">=6.2.0,<6.5.0"


### PR DESCRIPTION
This version contains a number of features and fixes that greatly help this role; while the role was able so far to work with older versions, let's require a recent version so it is possible to drop workarounds.

The upper version limit is unfortunately still needed for now.