### PR TITLE
refactor: pass rhc_baseurl directly to redhat_subscription

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -17,19 +17,6 @@
   changed_when: false
   failed_when: __rhc_subman_identity.rc not in [0, 1]
 
-- name: Change rhsm.baseurl
-  command:
-    argv:
-      - subscription-manager
-      - config
-      - "--rhsm.baseurl={{ rhc_baseurl }}"
-  changed_when: false
-  when:
-    - rhc_state | d("present") in ["present", "reconnect"]
-    - rhc_baseurl is not none
-    - rhc_baseurl != omit
-    - rhc_baseurl | string | length > 0
-
 - name: Call subscription-manager
   # noqa jinja[spacing]
   community.general.redhat_subscription:
@@ -93,6 +80,7 @@
     environment: "{{ rhc_environments | join(',')
       if (rhc_environments | length > 0
           and rhc_state | d('present') != 'absent') else omit }}"
+    rhsm_baseurl: "{{ rhc_baseurl | d(omit) }}"
 
 - name: Configure subscribed system
   when:


### PR DESCRIPTION
The `redhat_subscription` used to handle certain options both writing them to the config file (using `subscription-manager config`), and passing them as command line parameters to `subscription-manager register`. This was problematic for `rhsm_baseurl`, as subscription-manager sadly forces `https` as scheme when parsing `--baseurl` as passed to `register`. This was fixed with [1] (backported to community.general 6.x with [2]), available since community.general 6.1.0.

Hence, directly pass the `rhc_baseurl` role parameter as `rhsm_baseurl` parameter of the `redhat_subscription` module.

[1] https://github.com/ansible-collections/community.general/pull/5583
[2] https://github.com/ansible-collections/community.general/pull/5626