### PR TITLE
feat: implement rhc_proxy.scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,15 @@ The details of the proxy server to use for connecting:
 ```yaml
 rhc_proxy:
   hostname: "proxy-hostname"
+  scheme: http
   port: 4321
   username: "proxy-hostname"
   password: "proxy-password"
 ```
 
 * `hostname` is the hostname of the proxy server
+* `scheme` is the scheme to use for the proxy server, usually "http" or "https",
+  defaulting to "http"
 * `port` is the port to which connect to on the proxy server
 * `username` is the username to use for authenticating on the proxy server;
   it can be not specified if the proxy server does not require authentication

--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -55,6 +55,13 @@
       {%-   else -%}
       {{ rhc_proxy.hostname }}
       {%- endif %}"
+    server_proxy_scheme: "{% if rhc_proxy == __rhc_state_absent -%}
+      {{ 'http' }}
+      {%-   elif 'scheme' not in rhc_proxy -%}
+      {{ omit }}
+      {%-   else -%}
+      {{ rhc_proxy.scheme }}
+      {%- endif %}"
     server_proxy_port: "{% if rhc_proxy == __rhc_state_absent -%}
       {{ __rhc_empty_string }}
       {%-   elif 'port' not in rhc_proxy -%}

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,8 +25,10 @@ lsr_rhc_test_data:
     - {name: "repo2", state: disabled}
   release: "some-release"
   proxy_noauth_hostname: proxy-without-auth.hostname
+  proxy_noauth_scheme: http
   proxy_noauth_port: port
   proxy_auth_hostname: proxy-requiring-auth.hostname
+  proxy_auth_scheme: http
   proxy_auth_port: port
   proxy_auth_username: "proxy-username"
   proxy_auth_password: "proxy-password"
@@ -58,9 +60,13 @@ lsr_rhc_test_data:
 - the various `proxy_*` variables represent proxy-related bits:
    - `proxy_noauth_hostname` & `proxy_noauth_port` are the hostname & the port
      of a proxy server that does not require authentication
+   - `proxy_noauth_scheme` is the scheme for the proxy server that does not
+     require authentication; it can be not specified if the proxy type is "http"
    - `proxy_auth_hostname`, `proxy_auth_port`, `proxy_auth_username` &
      `proxy_auth_password` are the hostname & the port of a proxy server that
       requires authentication, together with the credentials for it
+   - `proxy_auth_scheme` is the scheme for the proxy server that requires
+     authentication; it can be not specified if the proxy type is "http"
    - `proxy_nonworking_hostname`, `proxy_nonworking_port`,
      `proxy_nonworking_username` & `proxy_nonworking_password` are wrong details
      of proxy server configuration bits

--- a/tests/files/candlepin_data.yml
+++ b/tests/files/candlepin_data.yml
@@ -18,8 +18,10 @@ lsr_rhc_test_data:
     - {name: "content-label-32060", state: disabled}
   release: null  # no releases in Candlepin test data
   proxy_noauth_hostname: localhost
+  proxy_noauth_scheme: http
   proxy_noauth_port: 3128
   proxy_auth_hostname: localhost
+  proxy_auth_scheme: http
   proxy_auth_port: 3130
   proxy_auth_username: "proxyuser"
   proxy_auth_password: "proxypass"

--- a/tests/tests_proxy.yml
+++ b/tests/tests_proxy.yml
@@ -141,6 +141,7 @@
         rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
         rhc_proxy:
           hostname: "{{ lsr_rhc_test_data.proxy_noauth_hostname }}"
+          scheme: "{{ lsr_rhc_test_data.proxy_noauth_scheme | d(omit) }}"
           port: "{{ lsr_rhc_test_data.proxy_noauth_port }}"
 
     - name: Unregister
@@ -174,6 +175,7 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_proxy:
               hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+              scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
               port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
 
         - name: Unreachable task
@@ -204,6 +206,7 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_proxy:
               hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+              scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
               port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
               username: "{{ lsr_rhc_test_data.proxy_nonworking_username }}"
               password: "{{ lsr_rhc_test_data.proxy_nonworking_password }}"
@@ -236,6 +239,7 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_proxy:
               hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+              scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
               port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
               username: "{{ lsr_rhc_test_data.proxy_nonworking_username }}"
               password: "{{ lsr_rhc_test_data.proxy_auth_password }}"
@@ -268,6 +272,7 @@
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
             rhc_proxy:
               hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+              scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
               port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
               username: "{{ lsr_rhc_test_data.proxy_auth_username }}"
               password: "{{ lsr_rhc_test_data.proxy_nonworking_password }}"
@@ -299,6 +304,7 @@
         rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
         rhc_proxy:
           hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+          scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
           port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
           username: "{{ lsr_rhc_test_data.proxy_auth_username }}"
           password: "{{ lsr_rhc_test_data.proxy_auth_password }}"


### PR DESCRIPTION
Starting with community.general 6.2.0, the `redhat_subscription` module has a `server_proxy_scheme` parameter to configure the type of proxy server that subscription-manager uses (see [1], backported to community.general 6.x with [2]).

Hence, add a `scheme` attribute for the `rhc_proxy` role parameter, allowing users to configure the proxy type. To make sure to be able to test this, also add new optional test variables, using them in "tests_proxy" if specified.

[1] https://github.com/ansible-collections/community.general/pull/5662
[2] https://github.com/ansible-collections/community.general/pull/5671