### PR TITLE
fix: correctly set release using new behavior of rhsm_release

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -46,7 +46,9 @@
           and not 'keys' in rhc_auth.activation_keys | d({})) else omit }}"
     release: "{{ rhc_release
       if (rhc_state | d('present') != 'absent'
-           and rhc_release != __rhc_state_absent)
+           and rhc_release != __rhc_state_absent
+           and not rhc_release is none
+           and rhc_release != omit)
       else omit }}"
     server_proxy_hostname: "{% if rhc_proxy == __rhc_state_absent -%}
       {{ __rhc_empty_string }}
@@ -93,21 +95,15 @@
   when:
     - rhc_state | d("present") in ["present", "reconnect"]
   block:
-    - name: Set the release
+    - name: Set or unset the release
       community.general.rhsm_release:
-        release: "{{ rhc_release }}"
+        release: "{{ rhc_release if rhc_release != __rhc_state_absent
+          else omit }}"
       when:
         - rhc_state | d("present") == "present"
         - __rhc_subman_identity.rc == 0
-        - rhc_release != __rhc_state_absent
-
-    - name: Unset the release
-      community.general.rhsm_release:
-        release: null
-      when:
-        - rhc_state | d("present") == "present"
-        - __rhc_subman_identity.rc == 0
-        - rhc_release == __rhc_state_absent
+        - not rhc_release is none
+        - rhc_release != omit
 
     - name: Configure repositories
       community.general.rhsm_repository:


### PR DESCRIPTION
The way the new version of rhsm_release works is - if the `release`
parameter is present, set the release to the given value.
If there is no `release` parameter, unset the release.
If the user does not set `rhc_release`, then it will be `null`,
and calling the rhsm_release module will be skipped.
See https://github.com/ansible-collections/community.general/pull/6401
for details.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>