### PR TITLE
chore(meta): temporarily stop supporting Fedora

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,9 +10,6 @@ galaxy_info:
   min_ansible_version: "2.9"
 
   platforms:
-    - name: Fedora
-      versions:
-        - all
     - name: EL
       versions:
         - "8"


### PR DESCRIPTION
- we need to update the community.general dependency to >= 6.6.0 to make the role working with with ansible-core >= 2.15 (adapting to a change in rhsm_release [1])
- unpin the community.general requirement means breaking the registration of Fedora managed nodes, as SELinux policies need to be adapted [2]
- [2] is temporarily broken by a dnf bug in Rawhide [3]

Since registration is already broken for people using the upstream redhat_subscription module in community.general, and registering Fedora system is a corner case, let's temporarily stop supporting Fedora systems. This will allow us to fix the role to make it usable with ansible-core >= 2.15; the support for Fedora will be added back when the Fedora SELinux policy will be fixed.

[1] https://github.com/ansible-collections/community.general/pull/6401
[2] https://github.com/fedora-selinux/selinux-policy/pull/1726
[3] https://bugzilla.redhat.com/show_bug.cgi?id=2210694