### PR TITLE
build: require community.general 6.6.0

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: community.general
-    version: ">=6.2.0"
+    version: ">=6.6.0"


### PR DESCRIPTION
This version contains a number of features and fixes that greatly help this role; while the role was able so far to work with older versions, let's require a recent version so it is possible to drop workarounds.

In particular, we need to require 6.6.0 so we can adapt to the new behaviour of rhsm_release [1], needed to run with ansible-core 2.15.

[1] https://github.com/ansible-collections/community.general/pull/6401