### PR TITLE
refactor: drop fake credential workaround

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -23,16 +23,8 @@
     state: "{{ 'present'
       if (rhc_state | d('present') == 'reconnect')
       else rhc_state | d('present') }}"
-    username: "{{ __rhc_fake_credential
-      if (rhc_state | d('present') == 'present'
-           and __rhc_subman_identity.rc == 0
-           and 'activation_keys' not in rhc_auth)
-      else (rhc_auth.login.username | d(omit)) }}"
-    password: "{{ __rhc_fake_credential
-      if (rhc_state | d('present') == 'present'
-           and __rhc_subman_identity.rc == 0
-           and 'activation_keys' not in rhc_auth)
-      else (rhc_auth.login.password | d(omit)) }}"
+    username: "{{ rhc_auth.login.username | d(omit) }}"
+    password: "{{ rhc_auth.login.password | d(omit) }}"
     activationkey: "{{ rhc_auth.activation_keys['keys'] | join(',')
       if ('keys' in rhc_auth.activation_keys | d({})) else omit }}"
     org_id: "{{ rhc_organization | d(omit) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,11 +20,6 @@ __rhc_required_fact_subsets:
 __rhc_state_absent:
   state: absent
 
-# this is a placeholder/fake credential to use in case we need to pass
-# credentials to the 'redhat_subscription' module, even when no registration
-# is needed
-__rhc_fake_credential: "this-is-not-a-credential!"
-
 # empty string, used in case a variable is needed for an empty string
 __rhc_empty_string: ""
 


### PR DESCRIPTION
The `redhat_subscription` module used to always require credentials when `state=present`; since we used the module also to do basic configuration of `subscription-manager`, this required us to pass fake credentials (unused) when the system was already registered. This behaviour was changed with [1] (backported to `community.general` 6.x with [2]), and available since `community.general` 6.5.0.

Hence, drop the concept of fake credential, and pass `username` and `password` only when specified; `redhat_subscription` still properly checks that only one credential type is specified.

[1] https://github.com/ansible-collections/community.general/pull/5664
[2] https://github.com/ansible-collections/community.general/pull/6222