### PR TITLE
perf: manually query for subscription status only when changing release

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -13,6 +13,8 @@
       - identity
   when:
     - rhc_state | d("present") == "present"
+    - not rhc_release is none
+    - rhc_release != omit
   register: __rhc_subman_identity
   changed_when: false
   failed_when: __rhc_subman_identity.rc not in [0, 1]
@@ -93,9 +95,9 @@
           else omit }}"
       when:
         - rhc_state | d("present") == "present"
-        - __rhc_subman_identity.rc == 0
         - not rhc_release is none
         - rhc_release != omit
+        - __rhc_subman_identity.rc == 0
 
     - name: Configure repositories
       community.general.rhsm_repository:


### PR DESCRIPTION
After commit bdfeb32fa3ff665e8e0fa8bfab63393786412b0f (i.e. the drop of the fake credentials), the registration status before invoking the `redhat_subscription` module is needed only because of the release setting. This is because the `redhat_subscription` module only sets a release when registering; on an already registered system, the `rshm_release` module is needed.

Hence, limit the query of the system registration status only in case there is a release change (i.e. `rhc_release` is different than null).

Followup of commit bdfeb32fa3ff665e8e0fa8bfab63393786412b0f