### PR TITLE
tests: ensure to always unregister

### DIFF
--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -8,97 +8,100 @@
     - name: Setup Insights
       import_tasks: tasks/setup_insights.yml
 
-    - name: Register insights
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          remediation: absent
-          state: present
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+    - name: Test Insights registration
+      block:
+        - name: Register insights
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              remediation: absent
+              state: present
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
-    - name: Register insights (noop)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          remediation: absent
-          state: present
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+        - name: Register insights (noop)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              remediation: absent
+              state: present
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
-    - name: Get insights UUID
-      include_tasks: tasks/get_insights_uuid.yml
+        - name: Get insights UUID
+          include_tasks: tasks/get_insights_uuid.yml
 
-    - name: Rename the insights UUID to test_insights_uuid_before
-      set_fact:
-        test_insights_uuid_before: "{{ test_insights_uuid }}"
+        - name: Rename the insights UUID to test_insights_uuid_before
+          set_fact:
+            test_insights_uuid_before: "{{ test_insights_uuid }}"
 
-    - name: Register (force)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          remediation: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_state: reconnect
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+        - name: Register (force)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              remediation: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_state: reconnect
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
-    - name: Get insights UUID
-      include_tasks: tasks/get_insights_uuid.yml
+        - name: Get insights UUID
+          include_tasks: tasks/get_insights_uuid.yml
 
-    - name: Rename the insights UUID to test_insights_uuid_after
-      set_fact:
-        test_insights_uuid_after: "{{ test_insights_uuid }}"
+        - name: Rename the insights UUID to test_insights_uuid_after
+          set_fact:
+            test_insights_uuid_after: "{{ test_insights_uuid }}"
 
-    - name: Check the insights UUID changed
-      assert:
-        that: test_insights_uuid_before != test_insights_uuid_after
+        - name: Check the insights UUID changed
+          assert:
+            that: test_insights_uuid_before != test_insights_uuid_after
 
-    - name: Unregister insights
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_insights:
-          state: absent
+        - name: Unregister insights
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_insights:
+              state: absent
 
-    - name: Unregister insights (noop)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_insights:
-          state: absent
+        - name: Unregister insights (noop)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_insights:
+              state: absent
 
-    - name: Unregister System
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
+      always:
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent

--- a/tests/tests_insights_remediation.yml
+++ b/tests/tests_insights_remediation.yml
@@ -8,59 +8,62 @@
     - name: Setup Insights
       import_tasks: tasks/setup_insights.yml
 
-    - name: Register insights and enable remediation
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          remediation: present
-          state: present
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+    - name: Test remediation
+      block:
+        - name: Register insights and enable remediation
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              remediation: present
+              state: present
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
-    - name: Get service_facts
-      service_facts:
+        - name: Get service_facts
+          service_facts:
 
-    - name: Check remediation is enabled
-      assert:
-        that:
-          - "'rhcd.service' in ansible_facts.services"
-          - ansible_facts.services['rhcd.service'].status == 'enabled'
+        - name: Check remediation is enabled
+          assert:
+            that:
+              - "'rhcd.service' in ansible_facts.services"
+              - ansible_facts.services['rhcd.service'].status == 'enabled'
 
-    - name: Disable remediation
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_insights:
-          remediation: absent
+        - name: Disable remediation
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_insights:
+              remediation: absent
 
-    - name: Get service_facts
-      service_facts:
+        - name: Get service_facts
+          service_facts:
 
-    - name: Check remediation is disabled
-      assert:
-        that:
-          - "'rhcd.service' in ansible_facts.services"
-          - ansible_facts.services['rhcd.service'].status == 'disabled'
+        - name: Check remediation is disabled
+          assert:
+            that:
+              - "'rhcd.service' in ansible_facts.services"
+              - ansible_facts.services['rhcd.service'].status == 'disabled'
 
-    - name: Disable remediation (noop)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_insights:
-          remediation: absent
+        - name: Disable remediation (noop)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_insights:
+              remediation: absent
 
-    - name: Unregister insights
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
+      always:
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent


### PR DESCRIPTION
Wrap a couple of Insights tests into blocks, so it is possible to always ensure the unregistration at the end of the tests, even in case of failure.

There should be no behaviour change w.r.t. what the tests themselves check.