### PR TITLE
fix: enable remediation only on RHEL >= 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ enabled by default.
 Whether the system is configured to run the Insights remediation; valid values
 are `present` (the default, to ensure remediation), and `absent`.
 
+Please note that the Insights remediation is supported only on RHEL 8.4 or
+greater, as the needed packages are available only starting from that version;
+on older versions, this parameter has no effect.
+
 ```yaml
     rhc_insights:
       tags: {}

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -58,7 +58,9 @@
   changed_when: true
 
 - name: Configure remediation
-  when: rhc_insights.remediation | d("present") == "present"
+  when:
+    - ansible_distribution_version is version("8.4", ">=")
+    - rhc_insights.remediation | d("present") == "present"
   block:
     - name: Ensure worker and ansible packages are installed
       package:

--- a/tests/tests_insights_remediation.yml
+++ b/tests/tests_insights_remediation.yml
@@ -8,6 +8,18 @@
     - name: Setup Insights
       import_tasks: tasks/setup_insights.yml
 
+    - name: Ensure ansible_facts used by the test
+      setup:
+        gather_subset:
+          - "!all"
+          - "!min"
+          - distribution_version
+
+    - name: Skip if the RHEL version is older than 8.4
+      meta: end_play
+      when:
+        - ansible_distribution_version is version("8.4", "<")
+
     - name: Test remediation
       block:
         - name: Register insights and enable remediation

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,7 @@
 __rhc_required_facts:
   - distribution
   - distribution_major_version
+  - distribution_version
 
 # the subsets of ansible_facts that need to be gathered in case any of the
 # fact in __rhc_required_facts is missing; see the documentation of
@@ -16,6 +17,7 @@ __rhc_required_fact_subsets:
   - "!min"
   - distribution
   - distribution_major_version
+  - distribution_version
 
 __rhc_state_absent:
   state: absent


### PR DESCRIPTION
The rhc-worker-playbook package, needed for the remediation support, is available in RHEL only starting from 8.4 (including 9); hence, do not attempt to setup remediation on older RHEL versions.