### PR TITLE
tests: disable rhc_insights.autoupdate when not needed

### DIFF
--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -19,6 +19,7 @@
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_insights:
+              autoupdate: false
               remediation: absent
               state: present
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
@@ -38,6 +39,7 @@
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_insights:
+              autoupdate: false
               remediation: absent
               state: present
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
@@ -64,6 +66,7 @@
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_insights:
+              autoupdate: false
               remediation: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:

--- a/tests/tests_insights_remediation.yml
+++ b/tests/tests_insights_remediation.yml
@@ -31,6 +31,7 @@
                 username: "{{ lsr_rhc_test_data.reg_username }}"
                 password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_insights:
+              autoupdate: false
               remediation: present
               state: present
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
@@ -55,6 +56,7 @@
             name: linux-system-roles.rhc
           vars:
             rhc_insights:
+              autoupdate: false
               remediation: absent
 
         - name: Get service_facts
@@ -71,6 +73,7 @@
             name: linux-system-roles.rhc
           vars:
             rhc_insights:
+              autoupdate: false
               remediation: absent
 
       always:


### PR DESCRIPTION
Disable the Insights autoupdate in all the tests that do not deal with autoupdate explicitly.

The two tests run fine when run with Stage.