### PR TITLE
fix: facts being gathered unnecessarily

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -3,8 +3,8 @@
 - name: Ensure ansible_facts used by role
   setup:
     gather_subset: "{{ __rhc_required_fact_subsets }}"
-  when: not ansible_facts.keys() | list |
-    intersect(__rhc_required_facts) == __rhc_required_facts
+  when: __rhc_required_facts |
+    difference(ansible_facts.keys() | list) | length > 0
 
 - name: Check if insights-packages are installed
   package_facts:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,12 +12,8 @@ __rhc_required_facts:
 # the subsets of ansible_facts that need to be gathered in case any of the
 # fact in __rhc_required_facts is missing; see the documentation of
 # the 'gather_subset' parameter of the 'setup' module
-__rhc_required_fact_subsets:
-  - "!all"
-  - "!min"
-  - distribution
-  - distribution_major_version
-  - distribution_version
+__rhc_required_fact_subsets: "{{ ['!all', '!min'] +
+  __rhc_required_facts }}"
 
 __rhc_state_absent:
   state: absent


### PR DESCRIPTION
Cause: The comparison of the present facts with the required facts is
being done on unsorted lists.

Consequence: The comparison may fail if the only difference is the
order.  Facts are gathered unnecessarily.

Fix: Use `difference` which works no matter what the order is.  Ensure
that the fact gathering subsets used are the absolute minimum required.

Result: The role gathers only the facts it requires, and does
not unnecessarily gather facts.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
