### PR TITLE
fix: use rhc_organization and rhc_baseurl only when specified

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -29,7 +29,10 @@
     password: "{{ rhc_auth.login.password | d(omit) }}"
     activationkey: "{{ rhc_auth.activation_keys['keys'] | join(',')
       if ('keys' in rhc_auth.activation_keys | d({})) else omit }}"
-    org_id: "{{ rhc_organization | d(omit) }}"
+    org_id: "{{ rhc_organization
+      if (not rhc_organization is none
+          and rhc_organization != omit)
+      else omit }}"
     server_hostname: "{{ rhc_server.hostname | d(omit) }}"
     server_port: "{{ rhc_server.port | d(omit) }}"
     server_prefix: "{{ rhc_server.prefix | d(omit) }}"
@@ -83,7 +86,10 @@
     environment: "{{ rhc_environments | join(',')
       if (rhc_environments | length > 0
           and rhc_state | d('present') != 'absent') else omit }}"
-    rhsm_baseurl: "{{ rhc_baseurl | d(omit) }}"
+    rhsm_baseurl: "{{ rhc_baseurl
+      if (not rhc_baseurl is none
+          and rhc_baseurl != omit)
+      else omit }}"
 
 - name: Configure subscribed system
   when:


### PR DESCRIPTION
rhc_organization and rhc_baseurl have "null" as default specified for them in defaults/main.yml, which means that the "d()" filter will never be used. Instead, check that they are non-null and non-omit, and use them only in that case.

Fixes commit b95a84e621bd98a74a5c57d5b76077895a7f71a0

Fixes #126

https://bugzilla.redhat.com/show_bug.cgi?id=2227821
https://bugzilla.redhat.com/show_bug.cgi?id=2227823