### PR TITLE
ci: update github action checkout to v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,6 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rhc
 
-[![ansible-lint.yml](https://github.com/linux-system-roles/rhc/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/linux-system-roles/rhc/actions/workflows/ansible-lint.yml) [![ansible-test.yml](https://github.com/linux-system-roles/rhc/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/linux-system-roles/rhc/actions/workflows/ansible-test.yml) [![markdownlint.yml](https://github.com/linux-system-roles/rhc/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/linux-system-roles/rhc/actions/workflows/markdownlint.yml) [![woke.yml](https://github.com/linux-system-roles/rhc/actions/workflows/woke.yml/badge.svg)](https://github.com/linux-system-roles/rhc/actions/workflows/woke.yml)
+[![woke.yml](https://github.com/linux-system-roles/rhc/actions/workflows/woke.yml/badge.svg)](https://github.com/linux-system-roles/rhc/actions/workflows/woke.yml) [![markdownlint.yml](https://github.com/linux-system-roles/rhc/actions/workflows/markdownlint.yml/badge.svg)](https://github.com/linux-system-roles/rhc/actions/workflows/markdownlint.yml) [![ansible-test.yml](https://github.com/linux-system-roles/rhc/actions/workflows/ansible-test.yml/badge.svg)](https://github.com/linux-system-roles/rhc/actions/workflows/ansible-test.yml) [![ansible-lint.yml](https://github.com/linux-system-roles/rhc/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/linux-system-roles/rhc/actions/workflows/ansible-lint.yml)
 
 ![rhc](https://github.com/linux-system-roles/template/workflows/tox/badge.svg)
 


### PR DESCRIPTION
Use v4 github action checkout
Update dependabot to include the "ci: " prefix in commit/pr titles
for PR title checking.
Tell dependabot to check weekly instead of monthly

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
