### PR TITLE
tests: use the containers.podman collection

### DIFF
--- a/tests/collection-requirements.yml
+++ b/tests/collection-requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
+  - name: containers.podman
   - name: fedora.linux_system_roles

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -23,22 +23,16 @@
         state: present
 
     - name: Start Candlepin container
-      command:
-        argv:
-          - podman
-          - run
-          - "--rm"
-          - "--detach"
-          - "--name"
-          - candlepin
-          - "--publish"
-          - "8443:8443"
-          - "--publish"
-          - "8080:8080"
-          - "--hostname"
-          - "{{ lsr_rhc_test_data.candlepin_host }}"
-          - ghcr.io/ptoscano/candlepin-unofficial
-      changed_when: false
+      containers.podman.podman_container:
+        detach: true
+        hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+        image: ghcr.io/ptoscano/candlepin-unofficial
+        name: candlepin
+        publish:
+          - 8443:8443
+          - 8080:8080
+        rm: true
+        state: started
 
     - name: Ensure directories exist
       file:


### PR DESCRIPTION
Make use of the `containers.podman` collection to ease the management of containers: in particular, the `podman_container` module is used to start the container of Candlepin. While the result is the same, using the `podman_container` module eases the handling of the parameters for the containers, which are now typed variables rather than untyped command line arguments.

There is no behaviour change.