### PR TITLE
refactor: improve support for ostree systems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,5 +22,3 @@ exclude_paths:
   - examples/roles/
 mock_roles:
   - linux-system-roles.rhc
-mock_modules:
-  - ansible.utils.update_fact

--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-role_collection_dir="${ROLE_COLLECTION_DIR:-fedora/linux_system_roles}"
 ostree_dir="${OSTREE_DIR:-"$(dirname "$(realpath "$0")")"}"
 
 if [ -z "${4:-}" ] || [ "${1:-}" = help ] || [ "${1:-}" = -h ]; then
@@ -29,7 +28,7 @@ if [ "$pkgtype" = testing ]; then
 fi
 
 get_rolepath() {
-    local ostree_dir role rolesdir roles_parent_dir
+    local ostree_dir role rolesdir roles_parent_dir coll_path path
     ostree_dir="$1"
     role="$2"
     roles_parent_dir="$(dirname "$(dirname "$ostree_dir")")"
@@ -47,16 +46,22 @@ get_rolepath() {
         fi
     done
     # look elsewhere
-    if [ -n "${ANSIBLE_COLLECTIONS_PATHS:-}" ]; then
-        for pth in ${ANSIBLE_COLLECTIONS_PATHS//:/ }; do
-            rolesdir="$pth/ansible_collections/$role_collection_dir/roles/$role/.ostree"
-            if [ -d "$rolesdir" ]; then
-                echo "$rolesdir"
-                return 0
-            fi
+    coll_path="${ANSIBLE_COLLECTIONS_PATH:-}"
+    if [ -z "$coll_path" ]; then
+        coll_path="${ANSIBLE_COLLECTIONS_PATHS:-}"
+    fi
+    if [ -n "${coll_path}" ]; then
+        for path in ${coll_path//:/ }; do
+            for rolesdir in "$path"/ansible_collections/*/*_system_roles/roles/"$role"/.ostree; do
+                if [ -d "$rolesdir" ]; then
+                    echo "$rolesdir"
+                    return 0
+                fi
+            done
         done
     fi
-    return 1
+    1>&2 echo ERROR - could not find role "$role" - please use ANSIBLE_COLLECTIONS_PATH
+    exit 2
 }
 
 get_packages() {
@@ -75,6 +80,10 @@ get_packages() {
             roles="$(cat "$rolefile")"
             for role in $roles; do
                 rolepath="$(get_rolepath "$ostree_dir" "$role")"
+                if [ -z "$rolepath" ]; then
+                    1>&2 echo ERROR - could not find role "$role" - please use ANSIBLE_COLLECTIONS_PATH
+                    exit 2
+                fi
                 get_packages "$rolepath"
             done
         fi

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
   - name: ansible.posix
-  - name: ansible.utils
   - name: community.general
     version: ">=6.6.0"

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -4,6 +4,8 @@
   package:
     name: insights-client
     state: present
+    use: "{{ __rhc_is_ostree |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
 - name: Call insights status
   include_tasks: check-insights-status.yml
@@ -69,6 +71,8 @@
           - rhc-worker-playbook
           - ansible-core
         state: present
+        use: "{{ __rhc_is_ostree |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Enable remediation
       systemd:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -6,23 +6,17 @@
   when: __rhc_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
-- name: Ensure correct package manager for ostree systems
-  vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-    ostree_booted_file: /run/ostree-booted
-  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+- name: Determine if system is ostree and set flag
+  when: not __rhc_is_ostree is defined
   block:
     - name: Check if system is ostree
       stat:
-        path: "{{ ostree_booted_file }}"
+        path: /run/ostree-booted
       register: __ostree_booted_stat
 
-    - name: Set package manager to use for ostree
-      ansible.utils.update_fact:
-        updates:
-          - path: ansible_facts.pkg_mgr
-            value: "{{ ostree_pkg_mgr }}"
-      when: __ostree_booted_stat.stat.exists
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __rhc_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
 - name: Check if insights-packages are installed
   package_facts:

--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -4,6 +4,8 @@
   package:
     name: "subscription-manager"
     state: present
+    use: "{{ __rhc_is_ostree |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: rhc_state | d('present') == "present"
 
 - name: Get subscription status

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -29,6 +29,8 @@
         name:
           - podman
         state: present
+        use: "{{ __rhc_is_ostree |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Start Candlepin container
       containers.podman.podman_container:

--- a/tests/tasks/setup_squid.yml
+++ b/tests/tasks/setup_squid.yml
@@ -10,6 +10,8 @@
           - squid
           - httpd-tools
         state: present
+        use: "{{ __rhc_is_ostree |
+                 ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Check the status of the backup of configuration
       stat:

--- a/tests/tasks/setup_test_data.yml
+++ b/tests/tasks/setup_test_data.yml
@@ -26,20 +26,14 @@
     file: ../files/candlepin_data.yml
   when: lsr_rhc_test_data_file | length == 0
 
-- name: Ensure correct package manager for ostree systems
-  vars:
-    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-    ostree_booted_file: /run/ostree-booted
-  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+- name: Determine if system is ostree and set flag
+  when: not __rhc_is_ostree is defined
   block:
     - name: Check if system is ostree
       stat:
-        path: "{{ ostree_booted_file }}"
+        path: /run/ostree-booted
       register: __ostree_booted_stat
 
-    - name: Set package manager to use for ostree
-      ansible.utils.update_fact:
-        updates:
-          - path: ansible_facts.pkg_mgr
-            value: "{{ ostree_pkg_mgr }}"
-      when: __ostree_booted_stat.stat.exists
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __rhc_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"


### PR DESCRIPTION
The dependency on `ansible.utils.update_fact` is causing issue with
some users who now must install that collection in order to run
the role, even if they do not care about ostree.

The fix is to stop trying to set `ansible_facts.pkg_mgr`, and instead
force the use of the ostree package manager with the `package:` module
`use:` option.  The strategy is - on ostree systems, set the flag
`__$ROLENAME_is_ostree` if the system is an ostree system.  The flag
will either be undefined or `false` on non-ostree systems.
Then, change every invocation of the `package:` module like this:

```yaml
- name: Ensure required packages are present
  package:
    name: "{{ __$ROLENAME_packages }}"
    state: present
    use: "{{ (__$ROLENAME_is_ostree | d(false)) |
      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
```

This should ensure that the `use:` parameter is not used if the system
is non-ostree.  The goal is to make the ostree support as unobtrusive
as possible for non-ostree systems.
The user can also set `__$ROLENAME_is_ostree: true` in the inventory or play
if the user knows that ostree is being used and wants to skip the check.
Or, the user is concerned about the performance hit for ostree detection
on non-ostree systems, and sets `__$ROLENAME_is_ostree: false` to skip
the check.
The flag `__$ROLENAME_is_ostree` can also be used in the role or tests to
include or exclude tasks from being run on ostree systems.

This fix also improves error reporting in the `get_ostree_data.sh` script
when included roles cannot be found.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
