### PR TITLE
chore: set a bash shebang recognized by ansible-test

### DIFF
--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -1,1 +1,0 @@
-roles/rhc/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -1,1 +1,0 @@
-roles/rhc/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,1 +1,0 @@
-roles/rhc/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -1,1 +1,0 @@
-roles/rhc/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,1 +1,0 @@
-roles/rhc/.ostree/get_ostree_data.sh shebang!skip


### PR DESCRIPTION
Few years ago, the `#!/bin/bash` shebang for bash scripts stopped to be allowed by ansible-test in favour of `#!/usr/bin/env bash` [1].

Hence, switch the fact script to `#!/usr/bin/env bash`, which will behave in the same way. This makes it possible to drop the ignores for this failure.

[1] https://github.com/ansible/ansible/pull/50954