### PR TITLE
tests: force recreating Candlepin container

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -43,6 +43,7 @@
         publish:
           - 8443:8443
           - 8080:8080
+        recreate: true
         rm: true
         state: started
 


### PR DESCRIPTION
It seems that the `podman_container` thinks that the container is changed, in case it is already running, and thus it tries to recreate it; this might be an already reported issue [1].

To avoid problems on this, force the creation of the container to a new one, in case it is running already. This also gives back a new clean Candlepin.

[1] https://github.com/containers/ansible-podman-collections/issues/532