### PR TITLE
tests: manually stop the Candlepin container

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -32,6 +32,11 @@
         use: "{{ __rhc_is_ostree |
                  ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
+    - name: Stop and remove Candlepin container
+      containers.podman.podman_container:
+        name: candlepin
+        state: absent
+
     - name: Start Candlepin container
       containers.podman.podman_container:
         detach: true
@@ -43,7 +48,6 @@
         publish:
           - 8443:8443
           - 8080:8080
-        recreate: true
         rm: true
         state: started
 


### PR DESCRIPTION
It seems the `podman_container` module cannot properly stop the running container when being asked using `recreate=true`; hence, do it manually before starting the new container.

This also reverts commit 12c1a38bd914547986509dbd1b9c955bc0f838f9, which is no more needed now.