### PR TITLE
feat: add ansible host parameter to insights configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ enabled by default.
 
 ```yaml
     rhc_insights:
+      ansible_host: "example-host"
+```
+
+Configures the ansible host name with a custom value for the system record
+in Host Based Inventory (HBI). This host name is used in playbooks by remediations.
+It is `null` by default and will use the system host name if not specified.
+
+Possible values of this variable:
+
+* `null` or an empty value: the ansible host name is not changed.
+* `{state: absent}`: the ansible host name is unset in the insights-client config file and Host Based Inventory (HBI) is updated to use the system host name.
+* any other string value: the ansible host name is changed in Host Based Inventory (HBI).
+
+```yaml
+    rhc_insights:
       remediation: present
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ rhc_auth: {}
 rhc_baseurl: null
 rhc_environments: []
 rhc_insights:
+  ansible_host: null
   autoupdate: true
   remediation: present
   state: present

--- a/tasks/insights-client-unregistration.yml
+++ b/tasks/insights-client-unregistration.yml
@@ -11,3 +11,9 @@
       or "Registered" in __rhc_insights_status.stdout
   register: __rhc_insights_unregister_result
   changed_when: true
+
+- name: Reset ansible host in config
+  lineinfile:
+    path: "{{ __rhc_insights_conf }}"
+    regexp: "^ansible_host="
+    state: absent

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -38,6 +38,62 @@
     insertafter: "#auto_update"
     line: auto_update={{ rhc_insights.autoupdate | d(true) | bool }}
 
+- name: Check ansible host in insights-client config
+  when:
+    - rhc_insights.ansible_host is defined
+    - not rhc_insights.ansible_host is none
+    - rhc_insights.ansible_host != __rhc_state_absent
+    - rhc_insights.ansible_host != omit
+  lineinfile:
+    path: "{{ __rhc_insights_conf }}"
+    regexp: "^ansible_host="
+    state: present
+    line: ansible_host={{ rhc_insights.ansible_host }}
+  check_mode: true
+  register: __insights_ansible_host_exists
+
+- name: Configure ansible host
+  when:
+    - rhc_insights.ansible_host is defined
+    - not rhc_insights.ansible_host is none
+    - rhc_insights.ansible_host != omit
+    - rhc_insights.ansible_host != __rhc_state_absent
+    - __insights_ansible_host_exists.changed
+  block:
+    - name: Update ansible host in insights-client config
+      lineinfile:
+        path: "{{ __rhc_insights_conf }}"
+        regexp: "^ansible_host="
+        insertafter: "#ansible_host="
+        line: ansible_host={{ rhc_insights.ansible_host }}
+    - name: Update ansible host in inventory
+      shell: >-
+        insights-client --ansible-host={{ rhc_insights.ansible_host }} & wait
+      when:
+        - >-
+          "This host is registered" in __rhc_insights_status.stdout
+          or "Registered" in __rhc_insights_status.stdout
+      changed_when: true
+
+- name: Remove ansible host
+  when:
+    - rhc_insights.ansible_host is defined
+    - rhc_insights.ansible_host == __rhc_state_absent
+  block:
+    - name: Remove ansible host from insights-client config
+      lineinfile:
+        path: "{{ __rhc_insights_conf }}"
+        regexp: "^ansible_host="
+        state: absent
+    - name: Remove ansible host in inventory
+      shell: insights-client --ansible-host= & wait
+      register: __insights_ansible_host_removed
+      when:
+        - >-
+          "This host is registered" in __rhc_insights_status.stdout
+          or "Registered" in __rhc_insights_status.stdout
+      changed_when: true
+
 - name: Register insights-client
   shell: insights-client --register & wait
   when:

--- a/tests/tests_insights_ansible_host.yaml
+++ b/tests/tests_insights_ansible_host.yaml
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Insights ansible host test
+  hosts: all
+  gather_facts: false
+  become: true
+
+  tasks:
+    - name: Setup Insights
+      import_tasks: tasks/setup_insights.yml
+
+    - name: Test ansible_host
+      block:
+        - name: Add ansible_host and register insights
+          include_role:
+            name: linux-system-roles.rhc
+            public: true
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              ansible_host: host
+              remediation: absent
+              state: present
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+        - name: Check ansible_host is set to 'host' in config file
+          command:
+            grep -ixq "^ansible_host=host" {{ __rhc_insights_conf }}
+          changed_when: true
+
+        - name: Test ansible_host changed value after registration
+          block:
+            - name: Change ansible host to 'new-host'
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  ansible_host: new-host
+                  remediation: absent
+            - name: Check ansible_host is set to 'new-host' in config file
+              command:
+                grep -ixq "^ansible_host=new-host" {{ __rhc_insights_conf }}
+              changed_when: false
+            - name: Change ansible host to a null value (noop)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  ansible_host: null
+                  remediation: absent
+            - name: Check ansible_host has not changed in config file
+              command:
+                grep -ixq "^ansible_host=new-host" {{ __rhc_insights_conf }}
+              changed_when: false
+
+        - name: Test ansible_host set to an absent value
+          block:
+            - name: Set ansible host to an absent value
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  ansible_host: {state: absent}
+                  remediation: absent
+            - name: Check ansible_host is not present in config file
+              lineinfile:
+                path: "{{ __rhc_insights_conf }}"
+                regexp: "^ansible_host="
+                state: absent
+              check_mode: true
+              register: __test_ansible_host_absent
+              failed_when: __test_ansible_host_absent.found
+
+        - name: Test ansible_host is removed during insights unregistration
+          block:
+            - name: Set ansible_host in config file
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  ansible_host: unreg-test
+                  remediation: absent
+            - name: Check ansible_host is set in config file
+              command:
+                grep -ixq "^ansible_host=unreg-test" {{ __rhc_insights_conf }}
+              changed_when: false
+            - name: Unregister insights to remove ansible_host in config file
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  state: absent
+            - name: Check ansible_host is not present in config file
+              lineinfile:
+                path: "{{ __rhc_insights_conf }}"
+                regexp: "^ansible_host="
+                state: absent
+              check_mode: true
+              register: __test_ansible_host_removed
+              failed_when: __test_ansible_host_removed.found
+
+      always:
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent


### PR DESCRIPTION
Adds the ansible host name option for insights-client
into the rhc role. This adds  support for setting an
ansible host name in inventory during insights-client
registration and updating the current ansible host name
in inventory if the system is already registered.

**Changes:**
 - Adds `ansible_host` parameter to insights client task to set/update/reset ansible host name in HBI.
 - Adds tests for ansible host name configuration.
 - Updates README with usage documentation for `ansible_host` parameter.

Signed-off-by: Jason Jerome <jajerome@redhat.com>