### PR TITLE
tests: temporarily pin Candlepin to 4.4.2

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -41,7 +41,7 @@
       containers.podman.podman_container:
         detach: true
         hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-        image: ghcr.io/ptoscano/candlepin-unofficial
+        image: ghcr.io/ptoscano/candlepin-unofficial:4.4.2-1
         name: candlepin
         privileged: "{{ ansible_distribution in ['CentOS', 'RedHat']
           and ansible_distribution_major_version | int < 8 }}"


### PR DESCRIPTION
The current latest release (4.4.3) introduces a regression that breaks the support for environments in subscription-manager. Since:
- we are not testing subscription-manager here, rather the rhc role
- the issue is already known by the Candlepin developers, and hopefully to be fixed in the next version

hence pin the Candlepin container to the latest version before the regression, i.e. 4.4.2. This way, we can keep testing changes in the rhc role.