### PR TITLE
Revert "tests: temporarily pin Candlepin to 4.4.2"

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -41,7 +41,7 @@
       containers.podman.podman_container:
         detach: true
         hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-        image: ghcr.io/ptoscano/candlepin-unofficial:4.4.2-1
+        image: ghcr.io/ptoscano/candlepin-unofficial
         name: candlepin
         privileged: "{{ ansible_distribution in ['CentOS', 'RedHat']
           and ansible_distribution_major_version | int < 8 }}"


### PR DESCRIPTION
Candlepin 4.4.4 fixes the regression that prevented environments to be used in subscription-manager. Hence, revert the container pinning, and keep using the latest version available.

This reverts commit 5e1bdc483baa335edf044e324fcd09d67b643359.