### PR TITLE
feat: Add a display name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,21 @@ Possible values of this variable:
 
 ```yaml
     rhc_insights:
+      display_name: "Example Host"
+```
+
+Configures the display name with a custom value for the system record in Host Based Inventory (HBI). This display name is only used to identify the host in the Inventory.
+It is `null` by default and will use the system host name if not specified.
+
+Possible values of this variable:
+
+* `null` or an empty string: the display name is not changed
+* any other string value: the display name is changed in Host Based Inventory (HBI).
+
+Note: If not set explicitly on registration, the display name is set to the hostname by default. It is not possible to automatically revert it to the hostname, but it can be set so manually.
+
+```yaml
+    rhc_insights:
       remediation: present
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ rhc_environments: []
 rhc_insights:
   ansible_host: null
   autoupdate: true
+  display_name: null
   remediation: present
   state: present
   tags: {}

--- a/tasks/insights-client-unregistration.yml
+++ b/tasks/insights-client-unregistration.yml
@@ -17,3 +17,9 @@
     path: "{{ __rhc_insights_conf }}"
     regexp: "^ansible_host="
     state: absent
+
+- name: Reset display name in config
+  lineinfile:
+    path: "{{ __rhc_insights_conf }}"
+    regexp: "^display_name="
+    state: absent

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -94,6 +94,43 @@
           or "Registered" in __rhc_insights_status.stdout
       changed_when: true
 
+- name: Check display name in insights-client config
+  when:
+    - rhc_insights.display_name is defined
+    - not rhc_insights.display_name is none
+    - rhc_insights.display_name != ""
+    - rhc_insights.display_name != omit
+  lineinfile:
+    path: "{{ __rhc_insights_conf }}"
+    regexp: "^display_name="
+    state: present
+    line: display_name={{ rhc_insights.display_name }}
+  check_mode: true
+  register: __insights_display_name_exists
+
+- name: Configure display name
+  when:
+    - rhc_insights.display_name is defined
+    - not rhc_insights.display_name is none
+    - rhc_insights.display_name != ""
+    - rhc_insights.display_name != omit
+    - __insights_display_name_exists.changed
+  block:
+    - name: Update display name in insights-client config
+      lineinfile:
+        path: "{{ __rhc_insights_conf }}"
+        regexp: "^display_name="
+        insertafter: "#display_name="
+        line: display_name={{ rhc_insights.display_name }}
+    - name: Update display name in inventory
+      shell: >-
+        insights-client --display-name={{ rhc_insights.display_name }} & wait
+      when:
+        - >-
+          "This host is registered" in __rhc_insights_status.stdout
+          or "Registered" in __rhc_insights_status.stdout
+      changed_when: true
+
 - name: Register insights-client
   shell: insights-client --register & wait
   when:

--- a/tests/tests_insights_display_name.yml
+++ b/tests/tests_insights_display_name.yml
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Insights display name test
+  hosts: all
+  gather_facts: false
+  become: true
+
+  tasks:
+    - name: Setup Insights
+      import_tasks: tasks/setup_insights.yml
+
+    - name: Test display_name
+      block:
+        - name: Add display_name and register insights
+          include_role:
+            name: linux-system-roles.rhc
+            public: true
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              display_name: name
+              remediation: absent
+              state: present
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+        - name: Check display_name is set to 'name' in config file
+          command:
+            grep -ixq "^display_name=name" {{ __rhc_insights_conf }}
+          changed_when: true
+
+        - name: Test display_name changed value after registration
+          block:
+            - name: Change display name to 'new-name'
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  display_name: new-name
+                  remediation: absent
+            - name: Check display_name is set to 'new-name' in config file
+              command:
+                grep -ixq "^display_name=new-name" {{ __rhc_insights_conf }}
+              changed_when: false
+            - name: Change display name to a null value (noop)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  display_name: null
+                  remediation: absent
+            - name: Check display_name has not changed in config file
+              command:
+                grep -ixq "^display_name=new-name" {{ __rhc_insights_conf }}
+              changed_when: false
+            - name: Change display name to an empty string (noop)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  display_name: ""
+                  remediation: absent
+            - name: Check display_name has not changed in config file
+              command:
+                grep -ixq "^display_name=new-name" {{ __rhc_insights_conf }}
+              changed_when: false
+
+        - name: Test display_name is removed during insights unregistration
+          block:
+            - name: Set display_name in config file
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  display_name: unreg-test
+                  remediation: absent
+            - name: Check display_name is set in config file
+              command:
+                grep -ixq "^display_name=unreg-test" {{ __rhc_insights_conf }}
+              changed_when: false
+            - name: Unregister insights to remove display_name in config file
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  state: absent
+            - name: Check display_name is not present in config file
+              lineinfile:
+                path: "{{ __rhc_insights_conf }}"
+                regexp: "^display_name="
+                state: absent
+              check_mode: true
+              register: __test_display_name_removed
+              failed_when: __test_display_name_removed.found
+
+      always:
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent


### PR DESCRIPTION
Enhancement:
A new _rhc_insights.display_name_ parameter.

Reason:
The display name is a value managed by Insights Client. It is visible in the Host-Based Inventory and is used as the main visible name in the UI to identify a host and search for it.

Result:
The new _rhc_insights.display_name_ parameter sets the display name of the host. This value is written to the Insights Client config file and also set directly by a `--display-name` command. When marked as absent or on unregistration, the value is removed from the config file.

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/CCT-13