### PR TITLE
fix: Ignore ansible_host: ""

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ It is `null` by default and will use the system host name if not specified.
 
 Possible values of this variable:
 
-* `null` or an empty value: the ansible host name is not changed.
+* `null` or an empty string: the ansible host name is not changed.
 * `{state: absent}`: the ansible host name is unset in the insights-client config file and Host Based Inventory (HBI) is updated to use the system host name.
 * any other string value: the ansible host name is changed in Host Based Inventory (HBI).
 

--- a/tasks/insights-client.yml
+++ b/tasks/insights-client.yml
@@ -42,6 +42,7 @@
   when:
     - rhc_insights.ansible_host is defined
     - not rhc_insights.ansible_host is none
+    - rhc_insights.ansible_host != ""
     - rhc_insights.ansible_host != __rhc_state_absent
     - rhc_insights.ansible_host != omit
   lineinfile:
@@ -56,6 +57,7 @@
   when:
     - rhc_insights.ansible_host is defined
     - not rhc_insights.ansible_host is none
+    - rhc_insights.ansible_host != ""
     - rhc_insights.ansible_host != omit
     - rhc_insights.ansible_host != __rhc_state_absent
     - __insights_ansible_host_exists.changed

--- a/tests/tests_insights_ansible_host.yml
+++ b/tests/tests_insights_ansible_host.yml
@@ -61,6 +61,17 @@
               command:
                 grep -ixq "^ansible_host=new-host" {{ __rhc_insights_conf }}
               changed_when: false
+            - name: Change ansible host to an empty string (noop)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_insights:
+                  ansible_host: ""
+                  remediation: absent
+            - name: Check ansible_host has not changed in config file
+              command:
+                grep -ixq "^ansible_host=new-host" {{ __rhc_insights_conf }}
+              changed_when: false
 
         - name: Test ansible_host set to an absent value
           block:


### PR DESCRIPTION
Enhancement:
Ignoring  _rhc.ansible_host_ if set to an empty string.

Reason:

The empty string value causes:

- the Ansible host name to be reset in the Inventory by `insights-client --ansible_host=`;
- a line `ansible_host=` to be put in the config file.

The former is a job of `{state: absent}`. An empty string should not cause such a desctructive operation. The latter is ignored by the Client and is equivatent to that line missing.

Result:
Consistently with a similar condition of the display_name parameter, an empty string ansible_host is treated as undefined. It’s the same behavior as with a null value.

Issue Tracker Tickets (Jira or BZ if any):
- https://issues.redhat.com/browse/CCT-398