### PR TITLE
fix: drop usage of "auto_attach" of the "redhat_subscription" module

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -40,9 +40,6 @@
     server_prefix: "{{ rhc_server.prefix | d(omit) }}"
     server_insecure: "{{ omit if (rhc_server.insecure | d(omit) == omit)
       else rhc_server.insecure | ternary('1', '0') }}"
-    auto_attach: "{{ true
-      if (rhc_state | d('present') in ['present', 'reconnect']
-          and not 'keys' in rhc_auth.activation_keys | d({})) else omit }}"
     release: "{{ rhc_release
       if (rhc_state | d('present') != 'absent'
            and rhc_release != __rhc_state_absent


### PR DESCRIPTION
`auto_attach` is supposed to automatically attach subscriptions for accounts in entitlement mode. in Simple Content Access mode, this option becomes a no-op in subscription-manager.

The usage of this option was originally added to help testing regardless of the content access mode, even if the role supports only SCA. Since the entitlement mode has been officially deprecated for a couple of years already, and it is going away soon, then stop using the `auto_attach` option of the `redhat_subscription` module.

There is no behaviour change.