### PR TITLE
tests: switch to an SCA account for Candlepin

### DIFF
--- a/tests/files/candlepin_data.yml
+++ b/tests/files/candlepin_data.yml
@@ -5,16 +5,16 @@ lsr_rhc_test_data:
   candlepin_port: 8443
   candlepin_prefix: /candlepin
   candlepin_insecure: false
-  reg_username: "admin"
-  reg_password: "admin"
+  reg_username: "doc"
+  reg_password: "password"
   reg_activation_keys:
     - "default_key"
   reg_invalid_username: "invalid-user"
   reg_invalid_password: "invalid-password"
-  reg_organization: "admin"
+  reg_organization: "donaldduck"
   baseurl: "http://localhost:8080"
   repositories:
-    - {name: "admin-content-label-5051", state: enabled}
+    - {name: "donaldy-content-label-7051", state: enabled}
     - {name: "content-label-32060", state: disabled}
   release: null  # no releases in Candlepin test data
   proxy_noauth_hostname: localhost

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -92,7 +92,7 @@
           - /etc/pki/product-default/
       changed_when: false
       loop:
-        - "5050"
+        - "7050"
 
     - name: Copy Candlepin CA certificate for subscription-manager
       command:
@@ -143,15 +143,15 @@
         url_password: "{{ lsr_rhc_test_data.reg_password }}"
       register: default_key
 
-    - name: Get pools for product 5050
+    - name: Get pools for product 7050
       uri:
-        url: "{{ _cp_url_owner }}/pools?product=5050"
+        url: "{{ _cp_url_owner }}/pools?product=7050"
         method: GET
         url_username: "{{ lsr_rhc_test_data.reg_username }}"
         url_password: "{{ lsr_rhc_test_data.reg_password }}"
       register: pools
 
-    - name: Add pools for product 5050 to default_key activation key
+    - name: Add pools for product 7050 to default_key activation key
       uri:
         url: "{{ _cp_url }}/activation_keys/{{ default_key.json[0].id }}/pools/{{ item.id }}"  # yamllint disable-line
         method: POST


### PR DESCRIPTION
The role officially supports only SCA, so switch the test account used in the self-deployed Candlepin to an SCA-only account.

As consequence, also adapt the product certificate & repositories used to what the new account can access to.

There are no behaviour changes.