### PR TITLE
tests: run podman directly instead of using containers.podman

### DIFF
--- a/tests/collection-requirements.yml
+++ b/tests/collection-requirements.yml
@@ -1,4 +1,3 @@
 ---
 collections:
-  - name: containers.podman
   - name: fedora.linux_system_roles

--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -37,23 +37,41 @@
                  ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     - name: Stop and remove Candlepin container
-      containers.podman.podman_container:
-        name: candlepin
-        state: absent
+      command:
+        argv:
+          - podman
+          - stop
+          - candlepin
+      register: podman_stop_status
+      failed_when:
+        - podman_stop_status.rc != 0
+        - '"no such container" not in podman_stop_status.stderr'
+      changed_when: false
 
     - name: Start Candlepin container
-      containers.podman.podman_container:
-        detach: true
-        hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-        image: ghcr.io/ptoscano/candlepin-unofficial
-        name: candlepin
-        privileged: "{{ ansible_distribution in ['CentOS', 'RedHat']
-          and ansible_distribution_major_version | int < 8 }}"
-        publish:
+      vars:
+        podman_run_cli:
+          - podman
+          - run
+          - --rm
+          - --detach
+          - --hostname
+          - "{{ lsr_rhc_test_data.candlepin_host }}"
+          - --name
+          - candlepin
+          - --publish
           - 8443:8443
+          - --publish
           - 8080:8080
-        rm: true
-        state: started
+          - "{{ '--privileged'
+            if (ansible_distribution in ['CentOS', 'RedHat']
+                and ansible_distribution_major_version | int < 8)
+            else '' }}"
+          - ghcr.io/ptoscano/candlepin-unofficial
+      command:
+        argv:
+          "{{ podman_run_cli | reject('match', '^$') | list }}"
+      changed_when: false
 
     - name: Ensure directories exist
       file:


### PR DESCRIPTION
Using the `containers.podman` collection to handle `podman` is a nice idea, however what that collection supports now is becoming more strict than what this role supports. Case in point: `containers.podman` now requires Python 3.6+ for the managed nodes, which breaks the testing of EL 7.

This means that sadly the setup of a self-deployed Candlepin needs to run `podman` commands manually; use the proper parameters for `podman run` depending on the OS.

The gymnastics of checking the return code & stderr of `podman stop` are needed because the `--ignore` option (which would be ideal) was introduced in `podman` 1.7.0, and EL 7 has `podman` 1.6.4.

There is no behaviour change.