### PR TITLE
ci: add YAML header to github action workflow files

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,3 +1,4 @@
+---
 name: PR Title Lint
 on:  # yamllint disable-line rule:truthy
   pull_request:

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,3 +1,4 @@
+---
 # yamllint disable rule:line-length
 name: Woke
 on:  # yamllint disable-line rule:truthy


### PR DESCRIPTION
Some github action workflow files were missing the YAML --- header.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
