### PR TITLE
tests: simplify distro check in tests_environments.yml

### DIFF
--- a/tests/tests_environments.yml
+++ b/tests/tests_environments.yml
@@ -85,10 +85,9 @@
           when:
             - >-
               ansible_distribution not in ["CentOS", "RedHat"]
-              or (ansible_distribution == "RedHat"
-                  and ansible_distribution_version is version("8.6", ">="))
               or (ansible_distribution == "CentOS"
                   and ansible_distribution_major_version | int >= 8)
+              or (ansible_distribution_version is version("8.6", ">="))
           block:
             - name: Get enabled environments
               include_tasks: tasks/list_environments.yml


### PR DESCRIPTION
Simplify a distro check in `tests_environments.yml` to ease potentially adding more EL distros:
- because of the short-circuiting of expressions, all the "or" conditions are run currently only on "CentOS" and "RedHat"
- since CentOS Stream is the only "unversioned" EL distro, move its condition as the first after the distro check
- drop the name check, leaving only the version check, in any other case (i.e. currently on "RedHat")

This makes is possible to support more EL distros in this check, and in case they are versioned all it is needed is to tweak the first condition (i.e. the check for `ansible_distribution not in ...`).

There is no behaviour change.