### PR TITLE
Adding rhc_pool_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ it was already connected; because of this, the role will always report a
 "changed" status.
 
 ```yaml
+    rhc_pool_ids:
+      - 0123456789abcdef0123456789abcdef: 2
+      - 1123456789abcdef0123456789abcdef: 4
+```
+
+The subscription pool IDs to consume
+
+```yaml
     rhc_organization: "your-organization"
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ rhc_insights:
   remediation: present
   state: present
   tags: {}
+rhc_pool_ids: []
 rhc_organization: null
 rhc_proxy: {}
 rhc_release: null

--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -29,6 +29,7 @@
       else rhc_state | d('present') }}"
     username: "{{ rhc_auth.login.username | d(omit) }}"
     password: "{{ rhc_auth.login.password | d(omit) }}"
+    pool_ids: "{{ rhc_pool_ids | d(omit) }}"
     activationkey: "{{ rhc_auth.activation_keys['keys'] | join(',')
       if ('keys' in rhc_auth.activation_keys | d({})) else omit }}"
     org_id: "{{ rhc_organization


### PR DESCRIPTION
Enhancement:
Adding pool_ids

Reason:
Enable users to attach a specific pool

Ref:
https://docs.ansible.com/ansible/latest/collections/community/general/redhat_subscription_module.html