### PR TITLE
tests: adjust UUID checks to newer versions of insights-core

### DIFF
--- a/tests/tests_insights_client_register.yml
+++ b/tests/tests_insights_client_register.yml
@@ -74,6 +74,9 @@
             rhc_state: reconnect
             rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
+        - name: Get rhsm UUID
+          include_tasks: tasks/get_rhsm_uuid.yml
+
         - name: Get insights UUID
           include_tasks: tasks/get_insights_uuid.yml
 
@@ -81,9 +84,11 @@
           set_fact:
             test_insights_uuid_after: "{{ test_insights_uuid }}"
 
-        - name: Check the insights UUID changed
+        - name: Check Insights UUID changed or same as rhsm UUID
           assert:
-            that: test_insights_uuid_before != test_insights_uuid_after
+            that: >
+              test_insights_uuid_before != test_insights_uuid_after
+              or test_insights_uuid_after == test_rhsm_uuid
 
         - name: Unregister insights
           include_role:


### PR DESCRIPTION
Starting from version 3.4.6 [1], insights-core (used internally by `insights-client`) adjusted its logic to generate the UUID (written in the `/etc/insights-client/machine-id` file): instead of a new random UUID, it uses the `subscription-manager` UUID in case the system is registered with it (which now is the only supported option).

The expectations in tests_insights_client_register were that, unregistering and registering again with `insights-client` would give a new UUID, which are no more true now. Thus adjust the checks to either check for the old behaviour, or check that the UUID is now the same as the rhsm UUID.

This is only a fix for the test, the behaviour of the role itself is correct.

[1] https://github.com/RedHatInsights/insights-core/pull/4057