### PR TITLE
tests: Cleanup candlepin container

### DIFF
--- a/tests/tasks/setup_candlepin.yml
+++ b/tests/tasks/setup_candlepin.yml
@@ -36,17 +36,8 @@
         use: "{{ __rhc_is_ostree |
                  ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
-    - name: Stop and remove Candlepin container
-      command:
-        argv:
-          - podman
-          - stop
-          - candlepin
-      register: podman_stop_status
-      failed_when:
-        - podman_stop_status.rc != 0
-        - '"no such container" not in podman_stop_status.stderr'
-      changed_when: false
+    - name: Clean up Candlepin container
+      include_tasks: teardown_candlepin.yml
 
     - name: Start Candlepin container
       vars:

--- a/tests/tasks/teardown_candlepin.yml
+++ b/tests/tasks/teardown_candlepin.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Teardown Candlepin container
+  when: lsr_rhc_test_data_file | length == 0
+  block:
+    - name: Check if the candlepin container exists
+      command:
+        argv:
+          - podman
+          - ps
+          - -a
+          - --filter
+          - name=candlepin
+      register: __rhc_candlepin_cont_exists
+      changed_when: false
+
+    - name: Ensure that Candlepin container doesn't exist
+      command:
+        argv:
+          - podman
+          - stop
+          - candlepin
+      changed_when: true
+      when: '"candlepin" in __rhc_candlepin_cont_exists.stdout'

--- a/tests/tests_environments.yml
+++ b/tests/tests_environments.yml
@@ -7,101 +7,106 @@
   tags:
     - tests::slow
   tasks:
-    - name: Setup Candlepin
-      import_tasks: tasks/setup_candlepin.yml
-      vars:
-        environments: true
-
-    - name: Skip if no test environments are set
-      meta: end_play
-      when:
-        - >-
-          lsr_rhc_test_data.envs_register is none
-          or lsr_rhc_test_data.envs_register | d([]) | length == 0
-
-    - name: Ensure ansible_facts used by the test
-      setup:
-        gather_subset:
-          - "!all"
-          - "!min"
-          - distribution
-          - distribution_major_version
-          - distribution_version
-
-    - name: Try to register (wrong environment)
+    - name: Basic repository enablement/disablement test
       block:
-        - name: Register (wrong environment)
-          include_role:
-            name: linux-system-roles.rhc
+        - name: Setup Candlepin
+          import_tasks: tasks/setup_candlepin.yml
           vars:
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
-            rhc_insights:
-              state: absent
-            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-            rhc_server:
-              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-              port: "{{ lsr_rhc_test_data.candlepin_port }}"
-              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
-            rhc_environments:
-              - "{{ lsr_rhc_test_data.env_nonworking }}"
+            environments: true
 
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
-
-    - name: Test environments on registration
-      block:
-        - name: Register (with existing environments)
-          include_role:
-            name: linux-system-roles.rhc
-          vars:
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
-            rhc_insights:
-              state: absent
-            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-            rhc_server:
-              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-              port: "{{ lsr_rhc_test_data.candlepin_port }}"
-              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
-            rhc_environments: "{{ lsr_rhc_test_data.envs_register }}"
-
-        # 'subscription-manager environments' has a '--list' option only
-        # in RHEL 8.6+ and greater (incl. RHEL 9+)
-        - name: Check the enabled environments
+        - name: Skip if no test environments are set
+          meta: end_play
           when:
             - >-
-              ansible_distribution not in ["CentOS", "RedHat"]
-              or (ansible_distribution == "CentOS"
-                  and ansible_distribution_major_version | int >= 8)
-              or (ansible_distribution_version is version("8.6", ">="))
+              lsr_rhc_test_data.envs_register is none
+              or lsr_rhc_test_data.envs_register | d([]) | length == 0
+
+        - name: Ensure ansible_facts used by the test
+          setup:
+            gather_subset:
+              - "!all"
+              - "!min"
+              - distribution
+              - distribution_major_version
+              - distribution_version
+
+        - name: Try to register (wrong environment)
           block:
-            - name: Get enabled environments
-              include_tasks: tasks/list_environments.yml
+            - name: Register (wrong environment)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+                rhc_environments:
+                  - "{{ lsr_rhc_test_data.env_nonworking }}"
 
-            - name: Check environments to enable are enabled
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
               assert:
-                that:
-                  - >-
-                    (lsr_rhc_test_data.envs_register | sort) ==
-                    (test_environments.stdout_lines | sort)
+                that: ansible_failed_result.msg != 'The above task must fail'
 
+        - name: Test environments on registration
+          block:
+            - name: Register (with existing environments)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+                rhc_environments: "{{ lsr_rhc_test_data.envs_register }}"
+
+            # 'subscription-manager environments' has a '--list' option only
+            # in RHEL 8.6+ and greater (incl. RHEL 9+)
+            - name: Check the enabled environments
+              when:
+                - >-
+                  ansible_distribution not in ["CentOS", "RedHat"]
+                  or (ansible_distribution == "CentOS"
+                      and ansible_distribution_major_version | int >= 8)
+                  or (ansible_distribution_version is version("8.6", ">="))
+              block:
+                - name: Get enabled environments
+                  include_tasks: tasks/list_environments.yml
+
+                - name: Check environments to enable are enabled
+                  assert:
+                    that:
+                      - >-
+                        (lsr_rhc_test_data.envs_register | sort) ==
+                        (test_environments.stdout_lines | sort)
+
+          always:
+            - name: Unregister
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_state: absent
       always:
-        - name: Unregister
-          include_role:
-            name: linux-system-roles.rhc
-          vars:
-            rhc_state: absent
+        - name: Clean up Candlepin container
+          include_tasks: tasks/teardown_candlepin.yml

--- a/tests/tests_proxy.yml
+++ b/tests/tests_proxy.yml
@@ -12,29 +12,119 @@
       - "{{ lsr_rhc_test_data.proxy_auth_port }}"
       - "{{ lsr_rhc_test_data.proxy_nonworking_port }}"
   tasks:
-    - name: Setup Candlepin
-      import_tasks: tasks/setup_candlepin.yml
-
-    - name: Setup Squid
-      import_tasks: tasks/setup_squid.yml
-
-    # The test proxy uses non-standard ports which are not
-    # in the default SELinux policy, so add them, and remove
-    # them at the end of the test
-    - name: Add SELinux policy for proxy ports
-      include_role:
-        name: fedora.linux_system_roles.selinux
-      vars:
-        selinux_ports:
-          - ports: "{{ __proxy_port_list }}"
-            proto: tcp
-            setype: squid_port_t
-            state: present
-            local: true
-
-    - name: Try to register (wrong host, wrong port)
+    - name: Basic proxy test
       block:
-        - name: Register (wrong host, wrong port)
+        - name: Setup Candlepin
+          import_tasks: tasks/setup_candlepin.yml
+
+        - name: Setup Squid
+          import_tasks: tasks/setup_squid.yml
+
+        # The test proxy uses non-standard ports which are not
+        # in the default SELinux policy, so add them, and remove
+        # them at the end of the test
+        - name: Add SELinux policy for proxy ports
+          include_role:
+            name: fedora.linux_system_roles.selinux
+          vars:
+            selinux_ports:
+              - ports: "{{ __proxy_port_list }}"
+                proto: tcp
+                setype: squid_port_t
+                state: present
+                local: true
+
+        - name: Try to register (wrong host, wrong port)
+          block:
+            - name: Register (wrong host, wrong port)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_proxy:
+                  hostname: "{{ lsr_rhc_test_data.proxy_nonworking_hostname }}"
+                  port: "{{ lsr_rhc_test_data.proxy_nonworking_port }}"
+
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
+
+        - name: Try to register (wrong host)
+          block:
+            - name: Register (wrong host)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_proxy:
+                  hostname: "{{ lsr_rhc_test_data.proxy_nonworking_hostname }}"
+                  port: "{{ lsr_rhc_test_data.proxy_noauth_port }}"
+
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
+
+        - name: Try to register (wrong port)
+          block:
+            - name: Register (wrong port)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_proxy:
+                  hostname: "{{ lsr_rhc_test_data.proxy_noauth_hostname }}"
+                  port: "{{ lsr_rhc_test_data.proxy_nonworking_port }}"
+
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
+
+        - name: Register (no authentication)
           include_role:
             name: linux-system-roles.rhc
           vars:
@@ -50,121 +140,161 @@
               port: "{{ lsr_rhc_test_data.candlepin_port }}"
               prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-            rhc_proxy:
-              hostname: "{{ lsr_rhc_test_data.proxy_nonworking_hostname }}"
-              port: "{{ lsr_rhc_test_data.proxy_nonworking_port }}"
-
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
-
-    - name: Try to register (wrong host)
-      block:
-        - name: Register (wrong host)
-          include_role:
-            name: linux-system-roles.rhc
-          vars:
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
-            rhc_insights:
-              state: absent
-            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-            rhc_server:
-              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-              port: "{{ lsr_rhc_test_data.candlepin_port }}"
-              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-            rhc_proxy:
-              hostname: "{{ lsr_rhc_test_data.proxy_nonworking_hostname }}"
-              port: "{{ lsr_rhc_test_data.proxy_noauth_port }}"
-
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
-
-    - name: Try to register (wrong port)
-      block:
-        - name: Register (wrong port)
-          include_role:
-            name: linux-system-roles.rhc
-          vars:
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
-            rhc_insights:
-              state: absent
-            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-            rhc_server:
-              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-              port: "{{ lsr_rhc_test_data.candlepin_port }}"
-              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_proxy:
               hostname: "{{ lsr_rhc_test_data.proxy_noauth_hostname }}"
-              port: "{{ lsr_rhc_test_data.proxy_nonworking_port }}"
+              scheme: "{{ lsr_rhc_test_data.proxy_noauth_scheme | d(omit) }}"
+              port: "{{ lsr_rhc_test_data.proxy_noauth_port }}"
 
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
+        - name: Check scheme
+          command: >-
+            grep '^proxy_scheme *= *{{ lsr_rhc_test_data.proxy_noauth_scheme }}'
+            /etc/rhsm/rhsm.conf
+          changed_when: false
+          when: "'proxy_noauth_scheme' in lsr_rhc_test_data"
 
-    - name: Register (no authentication)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          state: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
-        rhc_proxy:
-          hostname: "{{ lsr_rhc_test_data.proxy_noauth_hostname }}"
-          scheme: "{{ lsr_rhc_test_data.proxy_noauth_scheme | d(omit) }}"
-          port: "{{ lsr_rhc_test_data.proxy_noauth_port }}"
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent
 
-    - name: Check scheme
-      command: >-
-        grep '^proxy_scheme *= *{{ lsr_rhc_test_data.proxy_noauth_scheme }}'
-        /etc/rhsm/rhsm.conf
-      changed_when: false
-      when: "'proxy_noauth_scheme' in lsr_rhc_test_data"
+        - name: Setup authenticated Squid
+          import_tasks: tasks/setup_squid.yml
+          vars:
+            authentication: true
 
-    - name: Unregister
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
+        - name: Try to register (missing credentials)
+          block:
+            - name: Register (missing credentials)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_proxy:
+                  hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+                  scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
+                  port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
 
-    - name: Setup authenticated Squid
-      import_tasks: tasks/setup_squid.yml
-      vars:
-        authentication: true
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
 
-    - name: Try to register (missing credentials)
-      block:
-        - name: Register (missing credentials)
+        - name: Try to register (wrong username, wrong password)
+          block:
+            - name: Register (wrong username, wrong password)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_proxy:
+                  hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+                  scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
+                  port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
+                  username: "{{ lsr_rhc_test_data.proxy_nonworking_username }}"
+                  password: "{{ lsr_rhc_test_data.proxy_nonworking_password }}"
+
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
+
+        - name: Try to register (wrong username)
+          block:
+            - name: Register (wrong username)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_proxy:
+                  hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+                  scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
+                  port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
+                  username: "{{ lsr_rhc_test_data.proxy_nonworking_username }}"
+                  password: "{{ lsr_rhc_test_data.proxy_auth_password }}"
+
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
+
+        - name: Try to register (wrong password)
+          block:
+            - name: Register (wrong password)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                rhc_proxy:
+                  hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
+                  scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
+                  port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
+                  username: "{{ lsr_rhc_test_data.proxy_auth_username }}"
+                  password: "{{ lsr_rhc_test_data.proxy_nonworking_password }}"
+
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
+
+        - name: Register (authentication)
           include_role:
             name: linux-system-roles.rhc
           vars:
@@ -180,187 +310,62 @@
               port: "{{ lsr_rhc_test_data.candlepin_port }}"
               prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-            rhc_proxy:
-              hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
-              scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
-              port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
-
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
-
-    - name: Try to register (wrong username, wrong password)
-      block:
-        - name: Register (wrong username, wrong password)
-          include_role:
-            name: linux-system-roles.rhc
-          vars:
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
-            rhc_insights:
-              state: absent
-            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-            rhc_server:
-              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-              port: "{{ lsr_rhc_test_data.candlepin_port }}"
-              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-            rhc_proxy:
-              hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
-              scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
-              port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
-              username: "{{ lsr_rhc_test_data.proxy_nonworking_username }}"
-              password: "{{ lsr_rhc_test_data.proxy_nonworking_password }}"
-
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
-
-    - name: Try to register (wrong username)
-      block:
-        - name: Register (wrong username)
-          include_role:
-            name: linux-system-roles.rhc
-          vars:
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
-            rhc_insights:
-              state: absent
-            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-            rhc_server:
-              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-              port: "{{ lsr_rhc_test_data.candlepin_port }}"
-              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-            rhc_proxy:
-              hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
-              scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
-              port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
-              username: "{{ lsr_rhc_test_data.proxy_nonworking_username }}"
-              password: "{{ lsr_rhc_test_data.proxy_auth_password }}"
-
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
-
-    - name: Try to register (wrong password)
-      block:
-        - name: Register (wrong password)
-          include_role:
-            name: linux-system-roles.rhc
-          vars:
-            rhc_auth:
-              login:
-                username: "{{ lsr_rhc_test_data.reg_username }}"
-                password: "{{ lsr_rhc_test_data.reg_password }}"
-            rhc_insights:
-              state: absent
-            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-            rhc_server:
-              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-              port: "{{ lsr_rhc_test_data.candlepin_port }}"
-              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
             rhc_proxy:
               hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
               scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
               port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
               username: "{{ lsr_rhc_test_data.proxy_auth_username }}"
-              password: "{{ lsr_rhc_test_data.proxy_nonworking_password }}"
+              password: "{{ lsr_rhc_test_data.proxy_auth_password }}"
 
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
+        - name: Check scheme
+          command: >-
+            grep '^proxy_scheme *= *{{ lsr_rhc_test_data.proxy_auth_scheme }}'
+            /etc/rhsm/rhsm.conf
+          changed_when: false
+          when: "'proxy_auth_scheme' in lsr_rhc_test_data"
 
-    - name: Register (authentication)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          state: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
-        rhc_proxy:
-          hostname: "{{ lsr_rhc_test_data.proxy_auth_hostname }}"
-          scheme: "{{ lsr_rhc_test_data.proxy_auth_scheme | d(omit) }}"
-          port: "{{ lsr_rhc_test_data.proxy_auth_port }}"
-          username: "{{ lsr_rhc_test_data.proxy_auth_username }}"
-          password: "{{ lsr_rhc_test_data.proxy_auth_password }}"
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent
 
-    - name: Check scheme
-      command: >-
-        grep '^proxy_scheme *= *{{ lsr_rhc_test_data.proxy_auth_scheme }}'
-        /etc/rhsm/rhsm.conf
-      changed_when: false
-      when: "'proxy_auth_scheme' in lsr_rhc_test_data"
+        - name: Register (without proxy)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+            rhc_proxy: {"state":"absent"}
+      always:
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent
 
-    - name: Unregister
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
+        - name: Clean up Candlepin container
+          include_tasks: tasks/teardown_candlepin.yml
 
-    - name: Register (without proxy)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          state: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
-        rhc_proxy: {"state":"absent"}
-
-    - name: Unregister
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
-
-    - name: Remove SELinux policy for proxy ports
-      include_role:
-        name: fedora.linux_system_roles.selinux
-      vars:
-        selinux_ports:
-          - ports: "{{ __proxy_port_list }}"
-            proto: tcp
-            setype: squid_port_t
-            state: absent
-            local: true
+        - name: Remove SELinux policy for proxy ports
+          include_role:
+            name: fedora.linux_system_roles.selinux
+          vars:
+            selinux_ports:
+              - ports: "{{ __proxy_port_list }}"
+                proto: tcp
+                setype: squid_port_t
+                state: absent
+                local: true

--- a/tests/tests_register_unregister.yml
+++ b/tests/tests_register_unregister.yml
@@ -7,19 +7,45 @@
   tags:
     - tests::slow
   tasks:
-    - name: Setup Candlepin
-      import_tasks: tasks/setup_candlepin.yml
-
-    - name: Try to register using invalid credentials
+    - name: Basic register/unregister
       block:
-        - name: Register (wrong username, wrong password)
+        - name: Setup Candlepin
+          import_tasks: tasks/setup_candlepin.yml
+
+        - name: Try to register using invalid credentials
+          block:
+            - name: Register (wrong username, wrong password)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  login:
+                    username: "{{ lsr_rhc_test_data.reg_invalid_username }}"
+                    password: "{{ lsr_rhc_test_data.reg_invalid_password }}"
+                rhc_insights:
+                  state: absent
+                rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
+
+        - name: Register
           include_role:
             name: linux-system-roles.rhc
           vars:
             rhc_auth:
               login:
-                username: "{{ lsr_rhc_test_data.reg_invalid_username }}"
-                password: "{{ lsr_rhc_test_data.reg_invalid_password }}"
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
             rhc_insights:
               state: absent
             rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
@@ -28,96 +54,96 @@
               port: "{{ lsr_rhc_test_data.candlepin_port }}"
               prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+        - name: Register (noop)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+        - name: Get rhsm UUID
+          include_tasks: tasks/get_rhsm_uuid.yml
+
+        - name: Rename the rhsm UUID to test_rhsm_uuid_before
+          set_fact:
+            test_rhsm_uuid_before: "{{ test_rhsm_uuid }}"
+
+        - name: Register (force)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              login:
+                username: "{{ lsr_rhc_test_data.reg_username }}"
+                password: "{{ lsr_rhc_test_data.reg_password }}"
+            rhc_insights:
+              state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_state: reconnect
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+
+        - name: Get rhsm UUID
+          include_tasks: tasks/get_rhsm_uuid.yml
+
+        - name: Rename the rhsm UUID to test_rhsm_uuid_after
+          set_fact:
+            test_rhsm_uuid_after: "{{ test_rhsm_uuid }}"
+
+        - name: Check the rhsm UUID changed
           assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
+            that: test_rhsm_uuid_before.stdout != test_rhsm_uuid_after.stdout
 
-    - name: Register
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          state: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent
 
-    - name: Register (noop)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          state: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+        - name: Try to register using activation key with missing org
+          block:
+            - name: Register (activation key, missing org)
+              include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_auth:
+                  activation_keys:
+                    keys: "{{ lsr_rhc_test_data.reg_activation_keys }}"
+                rhc_insights:
+                  state: absent
+                rhc_server:
+                  hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+                  port: "{{ lsr_rhc_test_data.candlepin_port }}"
+                  prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+                  insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+                  rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
-    - name: Get rhsm UUID
-      include_tasks: tasks/get_rhsm_uuid.yml
+            - name: Unreachable task
+              fail:
+                msg: The above task must fail
+          rescue:
+            - name: Assert registration failed
+              assert:
+                that: ansible_failed_result.msg != 'The above task must fail'
 
-    - name: Rename the rhsm UUID to test_rhsm_uuid_before
-      set_fact:
-        test_rhsm_uuid_before: "{{ test_rhsm_uuid }}"
-
-    - name: Register (force)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          login:
-            username: "{{ lsr_rhc_test_data.reg_username }}"
-            password: "{{ lsr_rhc_test_data.reg_password }}"
-        rhc_insights:
-          state: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_state: reconnect
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
-
-    - name: Get rhsm UUID
-      include_tasks: tasks/get_rhsm_uuid.yml
-
-    - name: Rename the rhsm UUID to test_rhsm_uuid_after
-      set_fact:
-        test_rhsm_uuid_after: "{{ test_rhsm_uuid }}"
-
-    - name: Check the rhsm UUID changed
-      assert:
-        that: test_rhsm_uuid_before.stdout != test_rhsm_uuid_after.stdout
-
-    - name: Unregister
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
-
-    - name: Try to register using activation key with missing org
-      block:
-        - name: Register (activation key, missing org)
+        - name: Register (using activation keys)
           include_role:
             name: linux-system-roles.rhc
           vars:
@@ -126,63 +152,42 @@
                 keys: "{{ lsr_rhc_test_data.reg_activation_keys }}"
             rhc_insights:
               state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
             rhc_server:
               hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
               port: "{{ lsr_rhc_test_data.candlepin_port }}"
               prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
               insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-              rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
 
-        - name: Unreachable task
-          fail:
-            msg: The above task must fail
-      rescue:
-        - name: Assert registration failed
-          assert:
-            that: ansible_failed_result.msg != 'The above task must fail'
+        - name: Register (using activation keys, noop)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_auth:
+              activation_keys:
+                keys: "{{ lsr_rhc_test_data.reg_activation_keys }}"
+            rhc_insights:
+              state: absent
+            rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
+            rhc_server:
+              hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
+              port: "{{ lsr_rhc_test_data.candlepin_port }}"
+              prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
+              insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
+            rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+      always:
+        - name: Unregister
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent
 
-    - name: Register (using activation keys)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          activation_keys:
-            keys: "{{ lsr_rhc_test_data.reg_activation_keys }}"
-        rhc_insights:
-          state: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
+        - name: Unregister (noop)
+          include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent
 
-    - name: Register (using activation keys, noop)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_auth:
-          activation_keys:
-            keys: "{{ lsr_rhc_test_data.reg_activation_keys }}"
-        rhc_insights:
-          state: absent
-        rhc_organization: "{{ lsr_rhc_test_data.reg_organization }}"
-        rhc_server:
-          hostname: "{{ lsr_rhc_test_data.candlepin_host }}"
-          port: "{{ lsr_rhc_test_data.candlepin_port }}"
-          prefix: "{{ lsr_rhc_test_data.candlepin_prefix }}"
-          insecure: "{{ lsr_rhc_test_data.candlepin_insecure }}"
-        rhc_baseurl: "{{ lsr_rhc_test_data.baseurl | d(omit) }}"
-
-    - name: Unregister
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
-
-    - name: Unregister (noop)
-      include_role:
-        name: linux-system-roles.rhc
-      vars:
-        rhc_state: absent
+        - name: Clean up Candlepin container
+          include_tasks: tasks/teardown_candlepin.yml

--- a/tests/tests_repositories.yml
+++ b/tests/tests_repositories.yml
@@ -7,11 +7,11 @@
   tags:
     - tests::slow
   tasks:
-    - name: Setup Candlepin
-      import_tasks: tasks/setup_candlepin.yml
-
     - name: Test repositories
       block:
+        - name: Setup Candlepin
+          import_tasks: tasks/setup_candlepin.yml
+
         - name: Register
           include_role:
             name: linux-system-roles.rhc
@@ -94,10 +94,12 @@
               lsr_rhc_test_data.repositories.0.name in
               test_repositories.stdout_lines
 
-
       always:
         - name: Unregister
           include_role:
             name: linux-system-roles.rhc
           vars:
             rhc_state: absent
+
+        - name: Clean up Candlepin container
+          include_tasks: tasks/teardown_candlepin.yml


### PR DESCRIPTION
Enhancement: In always block, import a task to cleanup candlepin container in tests that import the task tests/tasks/setup_candlepin.yml, which starts candlepin container.

Reason: Candlepin container remains after test playbook finishes. If you remove `container-selinux` rpm, you got selinux denials because the container is running but selinux policies for containers are removed.
