### PR TITLE
Force rhc_organization variable to be interger

### DIFF
--- a/tasks/subscription-manager.yml
+++ b/tasks/subscription-manager.yml
@@ -31,7 +31,7 @@
     password: "{{ rhc_auth.login.password | d(omit) }}"
     activationkey: "{{ rhc_auth.activation_keys['keys'] | join(',')
       if ('keys' in rhc_auth.activation_keys | d({})) else omit }}"
-    org_id: "{{ rhc_organization
+    org_id: "{{ rhc_organization | string | default(omit)
       if (not rhc_organization is none
           and rhc_organization != omit)
       else omit }}"


### PR DESCRIPTION
Enhancement:
All values for `rhc_organization` should be interger values. This change asserts that requirement by ensuring the value is an integer before trying to register.

Reason:
In situations where we're unmarshaling data from json to form variables, it's possible that those values can be unmarshalled as floating point numbers. Which would be incompatible with the current org ID's. This change asserts that the type of number for rhc_organization should be an integer.

Result:


Issue Tracker Tickets (Jira or BZ if any):
Jira: https://issues.redhat.com/browse/OSPRH-15097