### PR TITLE
fix: add verbosity-based no_log to facts modules

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -26,6 +26,7 @@
 
 - name: Check if insights-packages are installed
   package_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
   when:
     - ansible_facts['distribution'] == "RedHat"
     - >-


### PR DESCRIPTION
Feature: Add verbosity-based no_log to facts modules.

Reason: Facts modules like package_facts produce verbose output that clutters logs during normal operation, making it difficult to review playbook execution.

Result:
  - package_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - Users can still see full facts output when debugging by running with increased verbosity
  - No impact on normal operation, just cleaner logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Conditionally hide package_facts output using no_log based on Ansible verbosity level.