### PR TITLE
fix: Use verbosity level 3 for no_log

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -26,7 +26,7 @@
 
 - name: Check if insights-packages are installed
   package_facts:
-  no_log: "{{ ansible_verbosity < 2 }}"
+  no_log: "{{ ansible_verbosity < 3 }}"
   when:
     - ansible_facts['distribution'] == "RedHat"
     - >-


### PR DESCRIPTION
Use `ansible_verbosity < 3` instead of `< 2` to show output with `-vvv` or higher.

## Summary by Sourcery

Enhancements:
- Relax the no_log verbosity threshold for the insights-packages package_facts task so its output is shown only when Ansible runs with verbosity 3 or above.