### PR TITLE
test: check for failed rhcd service due to el8 bug

### DIFF
--- a/tests/tests_insights_remediation.yml
+++ b/tests/tests_insights_remediation.yml
@@ -47,6 +47,11 @@
 
         - name: Get service_facts
           service_facts:
+          no_log: "{{ ansible_verbosity < 3 }}"
+
+        - name: Show yggdrasil_systemd_service status should be enabled
+          debug:
+            var: ansible_facts.services.get(yggdrasil_systemd_service, "not found")
 
         - name: Check remediation is enabled
           assert:
@@ -62,12 +67,25 @@
 
         - name: Get service_facts
           service_facts:
+          no_log: "{{ ansible_verbosity < 3 }}"
 
+        - name: Show yggdrasil_systemd_service status should be disabled
+          debug:
+            var: ansible_facts.services.get(yggdrasil_systemd_service, "not found")
+
+        # NOTE: Shutting down rhcd on EL8 sometimes can give the following error:
+        # cannot stop workers: cannot stop worker: cannot stop worker: cannot stop process os: process already finished
+        # which results in the status being 'failed' instead of 'disabled'
+        # https://access.redhat.com/solutions/7106551
         - name: Check remediation is disabled
           assert:
             that:
-              - yggdrasil_systemd_service in ansible_facts.services
-              - ansible_facts.services[yggdrasil_systemd_service].status == 'disabled'
+              - __info != {}
+              - __status == 'disabled' or (__state == 'stopped' and __status == 'failed')
+          vars:
+            __info: "{{ ansible_facts.services.get(yggdrasil_systemd_service, {}) }}"
+            __status: "{{ __info.get('status', '') }}"
+            __state: "{{ __info.get('state', '') }}"
 
         - name: Disable remediation (noop)
           include_tasks: tasks/run_role_with_clear_facts.yml


### PR DESCRIPTION
Due to https://access.redhat.com/solutions/7106551 the test will sometimes
fail on EL8 when disabling remediation.  Add a check to see if the service
has stopped with a failure.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Handle intermittent EL8 remediation shutdown failures in insights remediation tests by relaxing service status assertions and adding service status debugging.

Bug Fixes:
- Allow rhcd/yggdrasil remediation disablement tests to pass when the service stops with a failed state on EL8 due to a known systemd issue.

Tests:
- Log yggdrasil_systemd_service status via debug output and suppress service_facts logging at lower verbosity levels in insights remediation tests.