### PR TITLE
docs(changelog): version 1.7.3 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+[1.7.3] - 2026-05-13
+--------------------
+
+### Other Changes
+
+- test: check for failed rhcd service due to el8 bug (#280)
+
 [1.7.2] - 2026-05-12
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.7.3

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Documentation:
- Add changelog entry for version 1.7.3 describing a new test related to an rhcd service failure on EL8.