### PR TITLE
ci: do not run ci tests by default, require citest comment or label [citest_skip]

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,6 +2,13 @@
 name: Ansible Lint
 on:  # yamllint disable-line rule:truthy
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+  issue_comment:
+    types:
+      - created
   merge_group:
     branches:
       - main
@@ -16,11 +23,43 @@ env:
   LSR_ROLE2COLL_NAME: linux_system_roles
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   ansible_lint:
     if: |
-      !((github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[citest_skip]')) ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, '[citest_skip]')))
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest_ansible-lint]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_ansible-lint'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_ansible-lint'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_ansible-lint')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,10 +77,23 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       - name: Install tox, tox-lsr
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -2,6 +2,13 @@
 name: Check for ansible_managed variable use in comments
 on:  # yamllint disable-line rule:truthy
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+  issue_comment:
+    types:
+      - created
   merge_group:
     branches:
       - main
@@ -13,11 +20,43 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   ansible_managed_var_comment:
     if: |
-      !((github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[citest_skip]')) ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, '[citest_skip]')))
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest_ansible-managed-var-comment]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_ansible-managed-var-comment'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_ansible-managed-var-comment'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_ansible-managed-var-comment')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Update pip, git
@@ -27,10 +66,23 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       - name: Install tox, tox-lsr
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -2,6 +2,13 @@
 name: Ansible Test
 on:  # yamllint disable-line rule:truthy
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+  issue_comment:
+    types:
+      - created
   merge_group:
     branches:
       - main
@@ -16,11 +23,43 @@ env:
   LSR_ROLE2COLL_NAME: linux_system_roles
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   ansible_test:
     if: |
-      !((github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[citest_skip]')) ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, '[citest_skip]')))
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest_ansible-test]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_ansible-test'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_ansible-test'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_ansible-test')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # get all results, not just the first failure
@@ -41,10 +80,23 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       - name: Install tox, tox-lsr
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,20 +2,73 @@
 ---
 name: Codespell
 on:  # yamllint disable-line rule:truthy
-  - pull_request
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+  issue_comment:
+    types:
+      - created
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   codespell:
     if: |
-      !(github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[citest_skip]'))
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest_codespell]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_codespell'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_codespell'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_codespell')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       - name: Codespell
         uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -3,6 +3,13 @@
 name: Markdown Lint
 on:  # yamllint disable-line rule:truthy
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+  issue_comment:
+    types:
+      - created
   merge_group:
     branches:
       - main
@@ -14,11 +21,43 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   markdownlint:
     if: |
-      !((github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[citest_skip]')) ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, '[citest_skip]')))
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest_markdownlint]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_markdownlint'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_markdownlint'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_markdownlint')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Update pip, git
@@ -27,10 +66,23 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       # CHANGELOG.md is generated automatically from PR titles and descriptions
       # It might have issues but they are not critical

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
     types:
       - opened
       - synchronize
+      - labeled
       - reopened
       - edited
   merge_group:
@@ -14,8 +15,37 @@ on:  # yamllint disable-line rule:truthy
       - checks_requested
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   commit-checks:
+    if: |
+      (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_pr-title-lint'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && (github.event.action == 'synchronize'
+            || github.event.action == 'reopened'
+            || github.event.action == 'edited')
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_pr-title-lint'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_pr-title-lint')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -2,6 +2,13 @@
 name: Test
 on:  # yamllint disable-line rule:truthy
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+  issue_comment:
+    types:
+      - created
   merge_group:
     branches:
       - main
@@ -14,13 +21,45 @@ on:  # yamllint disable-line rule:truthy
 
 permissions:
   contents: read
+  pull-requests: read
   # This is required for the ability to create/update the Pull request status
   statuses: write
 jobs:
   scenario:
     if: |
-      !((github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[citest_skip]')) ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, '[citest_skip]')))
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest_qemu-kvm-integration-tests]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_qemu-kvm-integration-tests'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_qemu-kvm-integration-tests'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_qemu-kvm-integration-tests')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     runs-on: ubuntu-latest
 
     strategy:
@@ -51,10 +90,23 @@ jobs:
       ANSIBLE_INJECT_FACT_VARS: "false"
 
     steps:
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       - name: Check if platform is supported
         id: check_platform

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -3,6 +3,13 @@
 name: Test converting README.md to README.html
 on:  # yamllint disable-line rule:truthy
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+  issue_comment:
+    types:
+      - created
   merge_group:
     branches:
       - main
@@ -13,13 +20,46 @@ on:  # yamllint disable-line rule:truthy
       - main
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   test_converting_readme:
     if: |
-      !((github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[citest_skip]')) ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, '[citest_skip]')))
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest_test_converting_readme]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_test_converting_readme'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_test_converting_readme'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_test_converting_readme')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     runs-on: ubuntu-latest
     permissions:
+      pull-requests: read
       contents: write
     steps:
       - name: Update pip, git
@@ -28,10 +68,23 @@ jobs:
           sudo apt update
           sudo apt install -y git
 
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       - name: Remove badges from README.md prior to converting to HTML
         run: sed -i '1,8 {/^\[\!.*actions\/workflows/d}' README.md

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -1,11 +1,17 @@
 ---
 name: Run integration tests in Testing Farm
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
   issue_comment:
     types:
       - created
 permissions:
   contents: read
+  pull-requests: read
   # This is required for the ability to create/update the Pull request status
   statuses: write
 jobs:
@@ -14,15 +20,48 @@ jobs:
     # The concurrency key is used to prevent multiple workflows from running at the same time
     concurrency:
       # group name contains reponame-pr_num to allow simualteneous runs in different PRs
-      group: testing-farm-${{ github.event.repository.name }}-${{ github.event.issue.number }}
+      group: testing-farm-${{ github.event.repository.name }}-${{ github.event.issue.number || github.event.number }}
       cancel-in-progress: true
     # Let's schedule tests only on user request. NOT automatically.
     # Only repository owner or member can schedule tests
     if: |
-      github.event.issue.pull_request
-      && contains(github.event.comment.body, '[citest]')
-      && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      || github.event.comment.user.login == 'systemroller')
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest]')
+            || contains(github.event.comment.body, '[citest_tft]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest')
+            || contains(github.event.pull_request.labels.*.name, 'citest_tft'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest')
+            || contains(github.event.pull_request.labels.*.name, 'citest_tft'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest'
+            || github.event.label.name == 'citest_tft')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     runs-on: ubuntu-latest
     outputs:
       supported_platforms: ${{ steps.supported_platforms.outputs.supported_platforms }}
@@ -30,31 +69,29 @@ jobs:
       memory: ${{ steps.memory.outputs.memory }}
     steps:
       - name: Dump github context
+        if: env.SR_DEBUG == 'true'
         run:   echo "$GITHUB_CONTEXT"
         shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-
-      - name: Checkout repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
+          SR_DEBUG: 'false'  # set to true to debug
 
       - name: Get head sha of the PR
+        if: github.event_name == 'issue_comment'
         id: head_sha
         run: |
           head_sha=$(gh api "repos/$REPO/pulls/$PR_NO" --jq '.head.sha')
           echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
         env:
           REPO: ${{ github.repository }}
-          PR_NO: ${{ github.event.issue.number }}
+          PR_NO: ${{ github.event.issue.number || github.event.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout PR
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-          ref: ${{ steps.head_sha.outputs.head_sha }}
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       - name: Get memory
         id: memory
@@ -119,7 +156,7 @@ jobs:
             ansible_version: "2.17"
     runs-on: ubuntu-latest
     env:
-      ARTIFACTS_DIR_NAME: "tf_${{ github.event.repository.name }}-${{ github.event.issue.number }}_\
+      ARTIFACTS_DIR_NAME: "tf_${{ github.event.repository.name }}-${{ github.event.issue.number || github.event.number }}_\
         ${{ matrix.platform }}-${{ matrix.ansible_version }}_\
         ${{ needs.prepare_vars.outputs.datetime }}/artifacts"
       ARTIFACT_TARGET_DIR: /srv/pub/alt/${{ vars.SR_LSR_USER }}/logs
@@ -128,7 +165,7 @@ jobs:
         id: set_vars
         run: |
           printf -v DATETIME '%(%Y%m%d-%H%M%S)T' -1
-          ARTIFACTS_DIR_NAME="tf_${{ github.event.repository.name }}-${{ github.event.issue.number }}_\
+          ARTIFACTS_DIR_NAME="tf_${{ github.event.repository.name }}-${{ github.event.issue.number || github.event.number }}_\
           ${{ matrix.platform }}-${{ matrix.ansible_version }}_$DATETIME/artifacts"
           ARTIFACTS_TARGET_DIR=/srv/pub/alt/${{ vars.SR_LSR_USER }}/logs
           ARTIFACTS_DIR=$ARTIFACTS_TARGET_DIR/$ARTIFACTS_DIR_NAME
@@ -168,7 +205,7 @@ jobs:
           variables: "SR_ANSIBLE_VER=${{ matrix.ansible_version }};\
             SR_REPO_NAME=${{ github.event.repository.name }};\
             SR_GITHUB_ORG=${{ github.repository_owner }};\
-            SR_PR_NUM=${{ github.event.issue.number }};\
+            SR_PR_NUM=${{ github.event.issue.number || github.event.number }};\
             SR_ARTIFACTS_DIR=${{ steps.set_vars.outputs.ARTIFACTS_DIR }};\
             SR_TEST_LOCAL_CHANGES=false;\
             SR_LSR_USER=${{ vars.SR_LSR_USER }};\

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -12,7 +12,7 @@ env:
     This PR is for the purpose of triggering periodic CI testing.
     We don't currently have a way to trigger CI without a PR,
     so this PR serves that purpose.
-  COMMENT: "[citest]"
+  COMMENT: "[citest_tft]"
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -2,20 +2,73 @@
 # yamllint disable rule:line-length
 name: Woke
 on:  # yamllint disable-line rule:truthy
-  - pull_request
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+  issue_comment:
+    types:
+      - created
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   woke:
     if: |
-      !(github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[citest_skip]'))
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && (contains(github.event.comment.body, '[citest_all]')
+            || contains(github.event.comment.body, '[citest_woke]'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.comment.author_association)
+            || github.event.comment.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'opened'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_woke'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.pull_request.user.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'synchronize'
+        && (contains(github.event.pull_request.labels.*.name, 'citest_all')
+            || contains(github.event.pull_request.labels.*.name, 'citest_woke'))
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      ) || (
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && (github.event.label.name == 'citest_all'
+            || github.event.label.name == 'citest_woke')
+        && (contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                     github.event.pull_request.author_association)
+            || github.event.sender.login == 'systemroller')
+      )
     name: Detect non-inclusive language
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR head SHA
+        if: github.event_name == 'issue_comment'
+        id: head_sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euxo pipefail
+          head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
+          ref: ${{ steps.head_sha.outputs.head_sha || github.sha }}
 
       - name: Run lsr-woke-action
         # Originally, uses: get-woke/woke-action@v0


### PR DESCRIPTION
github action ci jobs are a precious resource - we only have 20 jobs - when multiple
PRs are submitted we may have to wait hours to get results.  We need to be explicit
about where and when to run ci jobs.

With this change, when a PR is created or updated, CI tests will not run automatically.
A role maintainer (OWNER, MEMBER, COLLABORATOR, or systemroller) must either comment
on the PR or add a label:

* `[citest_all]` comment or `citest_all` label - run all CI tests, including checks
  and Testing Farm integration tests
* `[citest_$test]` comment or `citest_$test` label - run only that test - for
  example, `[citest_ansible-lint]` or the `citest_ansible-lint` label
* For Testing Farm, `[citest_tft]` / `citest_tft` runs those tests.  `[citest]` /
  `citest` is still accepted for Testing Farm for backward compatibility.

Comments work on issue_comment; labels take effect when the PR is opened, when new
commits are pushed, or when the label is added.  These labels are managed by
system roles .github automation.
See https://github.com/linux-system-roles/.github/pull/186

If you use the `gh` command to interact with github, you can use
`gh pr comment $PRNUM -b '[citest_all]'`
or
`gh pr edit $PRNUM --add-label citest_all`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
