### PR TITLE
feat: Argument spec implementation for rhc role

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: MIT
+---
+argument_specs:
+  main:
+    short_description: The rhc role.
+    description: >
+      The rhc role connects RHEL systems to Red Hat subscription
+      management and Red Hat Insights. It configures
+      subscription-manager registration, repository enablement,
+      release locking, Insights client registration, remediation,
+      and proxy settings.
+    options:
+      rhc_auth:
+        type: dict
+        default: {}
+        description: >
+          Authentication credentials for subscription-manager
+          registration. Accepts either a `login` dictionary with
+          `username` and `password`, or an `activation_keys`
+          dictionary with a `keys` list. Only one authentication
+          method may be specified at a time.
+        options:
+          login:
+            type: dict
+            description: >
+              Username and password authentication for
+              subscription-manager.
+            options:
+              username:
+                type: str
+                required: true
+                description: >
+                  The subscription-manager username.
+              password:
+                type: str
+                required: true
+                description: >
+                  The subscription-manager password.
+          activation_keys:
+            type: dict
+            description: >
+              Activation key authentication. Requires
+              `rhc_organization` to be set.
+            options:
+              keys:
+                type: list
+                elements: str
+                required: true
+                description: >
+                  List of activation key names.
+      rhc_baseurl:
+        type: raw
+        default: null
+        description: >
+          The base URL for receiving content from the subscription
+          server. Accepts `null` or a URL string.
+      rhc_environments:
+        type: list
+        elements: str
+        default: []
+        description: >
+          List of content view environments to register against when
+          connecting an unregistered system.
+      rhc_insights:
+        type: dict
+        default:
+          ansible_host: null
+          autoupdate: true
+          display_name: null
+          remediation: present
+          state: present
+          tags: {}
+        description: >
+          Red Hat Insights client configuration for the system.
+        options:
+          ansible_host:
+            type: raw
+            default: null
+            description: >
+              Custom ansible host name for Host Based Inventory
+              (HBI). Accepts `null`, an empty string, a string
+              value, or `{"state": "absent"}` to unset the
+              configured name.
+          autoupdate:
+            type: bool
+            default: true
+            description: >
+              Whether insights-client automatically updates dynamic
+              configuration.
+          display_name:
+            type: raw
+            default: null
+            description: >
+              Custom display name for Host Based Inventory (HBI).
+              Accepts `null`, an empty string, or a string value.
+          remediation:
+            type: str
+            default: present
+            choices:
+              - present
+              - absent
+            description: >
+              Whether Insights remediation is enabled (`present`)
+              or disabled (`absent`). Supported on RHEL 8.4 and
+              later.
+          state:
+            type: str
+            default: present
+            choices:
+              - present
+              - absent
+            description: >
+              Whether the system is connected to Insights
+              (`present`) or disconnected (`absent`).
+          tags:
+            type: raw
+            default: {}
+            description: >
+              Tags applied to the system record in Host Based
+              Inventory. Accepts `null`, an empty dictionary,
+              `{"state": "absent"}` to remove all tags, or a
+              dictionary of arbitrary tag key/value pairs.
+      rhc_organization:
+        type: raw
+        default: null
+        description: >
+          The organization identifier for subscription-manager.
+          Accepts `null` or a string. Required when connecting with
+          activation keys or when the user belongs to multiple
+          organizations.
+      rhc_proxy:
+        type: dict
+        default: {}
+        description: >
+          Proxy server settings for subscription-manager and
+          Insights connections.
+        options:
+          state:
+            type: str
+            choices:
+              - absent
+            description: >
+              When set to `absent`, all proxy configuration is reset
+              and the proxy is disabled.
+          hostname:
+            type: str
+            description: >
+              The proxy server hostname.
+          scheme:
+            type: str
+            choices:
+              - http
+              - https
+            description: >
+              The proxy connection scheme.
+          port:
+            type: int
+            description: >
+              The proxy server port number.
+          username:
+            type: str
+            description: >
+              The username for proxy authentication.
+          password:
+            type: str
+            description: >
+              The password for proxy authentication.
+      rhc_release:
+        type: raw
+        default: null
+        description: >
+          The release version to lock the system to, such as `8.6`.
+          Accepts `null`, a release string, a numeric release value,
+          or `{"state": "absent"}` to unset the release.
+      rhc_repositories:
+        type: list
+        elements: dict
+        default: []
+        description: >
+          List of repositories to enable or disable on the system.
+        options:
+          name:
+            type: str
+            required: true
+            description: >
+              The repository name.
+          state:
+            type: str
+            default: enabled
+            choices:
+              - enabled
+              - disabled
+            description: >
+              Whether the repository should be `enabled` or
+              `disabled`.
+      rhc_server:
+        type: dict
+        default: {}
+        description: >
+          Registration server connection details for
+          subscription-manager.
+        options:
+          hostname:
+            type: str
+            description: >
+              The subscription server hostname.
+          port:
+            type: int
+            description: >
+              The subscription server port number.
+          prefix:
+            type: str
+            description: >
+              The API path prefix for the subscription server,
+              starting with `/`.
+          insecure:
+            type: bool
+            description: >
+              Whether to disable SSL certificate validation for the
+              subscription server.
+      rhc_state:
+        type: str
+        default: present
+        choices:
+          - present
+          - absent
+          - reconnect
+        description: >
+          Whether the system is connected to Red Hat (`present`),
+          disconnected (`absent`), or forcibly reconnected
+          (`reconnect`).

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -141,7 +141,8 @@ argument_specs:
               - absent
             description: >
               When set to `absent`, all proxy configuration is reset
-              and the proxy is disabled.
+              and the proxy is disabled. No other proxy fields may be
+              specified when `state` is `absent`.
           hostname:
             type: str
             description: >

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -39,7 +39,6 @@
   when:
     - rhc_state | d('present') in ['present', 'reconnect']
     - "'activation_keys' in rhc_auth"
-    - "'keys' in rhc_auth.activation_keys | d({})"
 
 - name: Assert rhc_proxy has only state when state is absent
   ansible.builtin.assert:

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Assert rhc_baseurl is null or a string
+  ansible.builtin.assert:
+    that:
+      - >-
+        (rhc_baseurl is none)
+        or rhc_baseurl is string
+    fail_msg: >-
+      rhc_baseurl must be null or a string,
+      got {{ rhc_baseurl | type_debug }}
+  when: rhc_baseurl is defined
+
+- name: Assert rhc_organization is null or a string
+  ansible.builtin.assert:
+    that:
+      - >-
+        (rhc_organization is none)
+        or rhc_organization is string
+    fail_msg: >-
+      rhc_organization must be null or a string,
+      got {{ rhc_organization | type_debug }}
+  when: rhc_organization is defined
+
+- name: Assert rhc_release is null, string, number, or a dictionary
+  ansible.builtin.assert:
+    that:
+      - >-
+        (rhc_release is none)
+        or rhc_release is string
+        or ((rhc_release | type_debug) in ['int', 'float'])
+        or rhc_release is mapping
+    fail_msg: >-
+      rhc_release must be null, a string, a number, or a dictionary,
+      got {{ rhc_release | type_debug }}
+  when: rhc_release is defined
+
+- name: Assert rhc_insights.ansible_host is null, string, or a dictionary
+  ansible.builtin.assert:
+    that:
+      - >-
+        (rhc_insights.ansible_host is none)
+        or rhc_insights.ansible_host is string
+        or rhc_insights.ansible_host is mapping
+    fail_msg: >-
+      rhc_insights.ansible_host must be null, a string, or a dictionary,
+      got {{ rhc_insights.ansible_host | type_debug }}
+  when: rhc_insights.ansible_host is defined
+
+- name: Assert rhc_insights.display_name is null or a string
+  ansible.builtin.assert:
+    that:
+      - >-
+        (rhc_insights.display_name is none)
+        or rhc_insights.display_name is string
+    fail_msg: >-
+      rhc_insights.display_name must be null or a string,
+      got {{ rhc_insights.display_name | type_debug }}
+  when: rhc_insights.display_name is defined
+
+- name: Assert rhc_insights.tags is null or a dictionary
+  ansible.builtin.assert:
+    that:
+      - >-
+        (rhc_insights.tags is none)
+        or rhc_insights.tags is mapping
+    fail_msg: >-
+      rhc_insights.tags must be null or a dictionary,
+      got {{ rhc_insights.tags | type_debug }}
+  when: rhc_insights.tags is defined

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -22,6 +22,36 @@
       got {{ rhc_organization | type_debug }}
   when: rhc_organization is defined
 
+- name: Assert rhc_auth does not specify both login and activation_keys
+  ansible.builtin.assert:
+    that:
+      - not ('login' in rhc_auth and 'activation_keys' in rhc_auth)
+    fail_msg: >-
+      rhc_auth must specify either login or activation_keys, not both
+  when: rhc_auth is mapping
+
+- name: Assert rhc_organization is set when using activation_keys
+  ansible.builtin.assert:
+    that:
+      - rhc_organization | default('', true) | length > 0
+    fail_msg: >-
+      rhc_organization is required when rhc_auth.activation_keys is set
+  when:
+    - rhc_state | d('present') in ['present', 'reconnect']
+    - "'activation_keys' in rhc_auth"
+    - "'keys' in rhc_auth.activation_keys | d({})"
+
+- name: Assert rhc_proxy has only state when state is absent
+  ansible.builtin.assert:
+    that:
+      - rhc_proxy.keys() | list | difference(['state']) | length == 0
+    fail_msg: >-
+      rhc_proxy must contain only state when state is absent,
+      got keys {{ rhc_proxy.keys() | list | join(', ') }}
+  when:
+    - rhc_proxy is mapping
+    - rhc_proxy.state | d('') == 'absent'
+
 - name: Assert rhc_release is null, string, number, or a dictionary
   ansible.builtin.assert:
     that:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,9 @@
 - name: Set ansible_facts required by role
   include_tasks: set_vars.yml
 
+- name: Validate role parameters
+  ansible.builtin.include_tasks: assert_role_vars.yml
+
 - name: Handle insights unregistration
   include_tasks: insights-client-unregistration.yml
   when:

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -13,6 +13,22 @@
           vars:
             rhc_state: absent
 
+        - name: Check subscription-manager registration status
+          ansible.builtin.command:
+            argv:
+              - subscription-manager
+              - identity
+          register: __rhc_identity_after_absent
+          changed_when: false
+          failed_when: false
+
+        - name: Assert system is disconnected from Red Hat
+          ansible.builtin.assert:
+            that:
+              - __rhc_identity_after_absent.rc != 0
+            fail_msg: >-
+              rhc_state absent should leave the system unregistered
+
         # ====================================================
         # Section 2: argument_specs validation (Ansible 2.11+)
         # ====================================================
@@ -285,6 +301,29 @@
               assert_role_vars should reject activation_keys when
               rhc_organization is not set
 
+        - name: Assert rejects empty activation_keys without rhc_organization
+          block:
+            - name: Run role with empty activation_keys and reconnect
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                rhc_state: reconnect
+                rhc_auth:
+                  activation_keys: {}
+          rescue:
+            - name: Mark empty activation_keys without organization rejected
+              ansible.builtin.set_fact:
+                __invalid_input_activation_keys_empty_no_org_failed: true
+
+        - name: Assert empty activation_keys without organization was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_activation_keys_empty_no_org_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject activation_keys when
+              rhc_organization is not set, even if keys is empty
+
         - name: Assert rejects rhc_proxy state absent with extra fields
           block:
             - name: Run role with rhc_proxy state absent and hostname
@@ -322,5 +361,6 @@
             __invalid_input_rhc_insights_ansible_host_int_failed:
             __invalid_input_rhc_auth_both_methods_failed:
             __invalid_input_activation_keys_no_org_failed:
+            __invalid_input_activation_keys_empty_no_org_failed:
             __invalid_input_rhc_proxy_absent_extra_failed:
           tags: tests::cleanup

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Verify invalid parameters are rejected
+  hosts: all
+  tasks:
+    - name: Run invalid input tests
+      block:
+        # ====================================================
+        # Section 1: Verify role works with valid parameters
+        # ====================================================
+        - name: Run role with valid parameters
+          ansible.builtin.include_role:
+            name: linux-system-roles.rhc
+          vars:
+            rhc_state: absent
+
+        # ====================================================
+        # Section 2: argument_specs validation (Ansible 2.11+)
+        # ====================================================
+        - name: Run argument specs validation tests
+          when: ansible_version.full is version("2.11", ">=")
+          block:
+            - name: Argument specs reject missing required repository name
+              block:
+                - name: Run role without required repository name
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.rhc
+                  vars:
+                    rhc_state: absent
+                    rhc_repositories:
+                      - state: enabled
+              rescue:
+                - name: Mark missing repository name rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_missing_repo_name_failed: true
+                  when: >-
+                    'missing required arguments' in
+                    (ansible_failed_result | default({}) | to_json)
+
+            - name: Assert missing repository name was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_missing_repo_name_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject rhc_repositories entries
+                  missing the required name field
+
+            - name: Argument specs reject non-string rhc_state
+              block:
+                - name: Run role with non-string rhc_state
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.rhc
+                  vars:
+                    rhc_state: 123
+              rescue:
+                - name: Mark invalid rhc_state type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_rhc_state_type_failed: true
+
+            - name: Assert invalid rhc_state type was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_rhc_state_type_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject rhc_state with type int
+
+            - name: Argument specs reject invalid rhc_state choice
+              block:
+                - name: Run role with invalid rhc_state value
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.rhc
+                  vars:
+                    rhc_state: invalid_choice
+              rescue:
+                - name: Mark invalid rhc_state choice rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_rhc_state_choice_failed: true
+
+            - name: Assert invalid rhc_state choice was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_rhc_state_choice_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject rhc_state value
+                  'invalid_choice'
+
+            - name: Argument specs reject invalid rhc_insights.state choice
+              block:
+                - name: Run role with invalid rhc_insights.state value
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.rhc
+                  vars:
+                    rhc_state: absent
+                    rhc_insights:
+                      state: invalid_choice
+              rescue:
+                - name: Mark invalid rhc_insights.state choice rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_rhc_insights_state_choice_failed: true
+
+            - name: Assert invalid rhc_insights.state choice was rejected
+              ansible.builtin.assert:
+                that:
+                  - >-
+                    __invalid_input_rhc_insights_state_choice_failed
+                    | default(false)
+                fail_msg: >-
+                  argument_specs should reject rhc_insights.state value
+                  'invalid_choice'
+
+            - name: Argument specs reject invalid repository state choice
+              block:
+                - name: Run role with invalid repository state value
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.rhc
+                  vars:
+                    rhc_state: absent
+                    rhc_repositories:
+                      - name: test-repo
+                        state: invalid_choice
+              rescue:
+                - name: Mark invalid repository state choice rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_repo_state_choice_failed: true
+
+            - name: Assert invalid repository state choice was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_repo_state_choice_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject rhc_repositories state value
+                  'invalid_choice'
+
+            - name: Argument specs reject non-boolean rhc_insights.autoupdate
+              block:
+                - name: Run role with non-boolean rhc_insights.autoupdate
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.rhc
+                  vars:
+                    rhc_state: absent
+                    rhc_insights:
+                      autoupdate: not_a_bool
+              rescue:
+                - name: Mark invalid rhc_insights.autoupdate type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_autoupdate_type_failed: true
+
+            - name: Assert invalid rhc_insights.autoupdate type was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_autoupdate_type_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject rhc_insights.autoupdate
+                  with type str
+
+        # ====================================================
+        # Section 3: assert_role_vars validation (all versions)
+        # ====================================================
+        - name: Assert rejects rhc_release as a list
+          block:
+            - name: Run role with rhc_release as a list
+              ansible.builtin.include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_state: absent
+                rhc_release:
+                  - "8.6"
+          rescue:
+            - name: Mark rhc_release list rejected
+              ansible.builtin.set_fact:
+                __invalid_input_rhc_release_list_failed: true
+
+        - name: Assert rhc_release as list was rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_rhc_release_list_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject rhc_release when given
+              a list value
+
+        - name: Assert rejects rhc_baseurl as an integer
+          block:
+            - name: Run role with rhc_baseurl as an integer
+              ansible.builtin.include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_state: absent
+                rhc_baseurl: 123
+          rescue:
+            - name: Mark rhc_baseurl integer rejected
+              ansible.builtin.set_fact:
+                __invalid_input_rhc_baseurl_int_failed: true
+
+        - name: Assert rhc_baseurl as integer was rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_rhc_baseurl_int_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject rhc_baseurl when given
+              an integer value
+
+        - name: Assert rejects rhc_insights.tags as a string
+          block:
+            - name: Run role with rhc_insights.tags as a string
+              ansible.builtin.include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_state: absent
+                rhc_insights:
+                  tags: not_a_dict
+          rescue:
+            - name: Mark rhc_insights.tags string rejected
+              ansible.builtin.set_fact:
+                __invalid_input_rhc_insights_tags_str_failed: true
+
+        - name: Assert rhc_insights.tags as string was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_rhc_insights_tags_str_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject rhc_insights.tags when given
+              a string value
+
+        - name: Assert rejects rhc_insights.ansible_host as an integer
+          block:
+            - name: Run role with rhc_insights.ansible_host as an integer
+              ansible.builtin.include_role:
+                name: linux-system-roles.rhc
+              vars:
+                rhc_state: absent
+                rhc_insights:
+                  ansible_host: 123
+          rescue:
+            - name: Mark rhc_insights.ansible_host integer rejected
+              ansible.builtin.set_fact:
+                __invalid_input_rhc_insights_ansible_host_int_failed: true
+
+        - name: Assert rhc_insights.ansible_host as integer was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_rhc_insights_ansible_host_int_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject rhc_insights.ansible_host
+              when given an integer value
+
+      always:
+        - name: Clear test facts
+          ansible.builtin.set_fact:
+            __invalid_input_missing_repo_name_failed:
+            __invalid_input_rhc_state_type_failed:
+            __invalid_input_rhc_state_choice_failed:
+            __invalid_input_rhc_insights_state_choice_failed:
+            __invalid_input_repo_state_choice_failed:
+            __invalid_input_autoupdate_type_failed:
+            __invalid_input_rhc_release_list_failed:
+            __invalid_input_rhc_baseurl_int_failed:
+            __invalid_input_rhc_insights_tags_str_failed:
+            __invalid_input_rhc_insights_ansible_host_int_failed:
+          tags: tests::cleanup

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -9,8 +9,7 @@
         # Section 1: Verify role works with valid parameters
         # ====================================================
         - name: Run role with valid parameters
-          ansible.builtin.include_role:
-            name: linux-system-roles.rhc
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             rhc_state: absent
 
@@ -23,8 +22,7 @@
             - name: Argument specs reject missing required repository name
               block:
                 - name: Run role without required repository name
-                  ansible.builtin.include_role:
-                    name: linux-system-roles.rhc
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     rhc_state: absent
                     rhc_repositories:
@@ -48,8 +46,7 @@
             - name: Argument specs reject non-string rhc_state
               block:
                 - name: Run role with non-string rhc_state
-                  ansible.builtin.include_role:
-                    name: linux-system-roles.rhc
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     rhc_state: 123
               rescue:
@@ -67,8 +64,7 @@
             - name: Argument specs reject invalid rhc_state choice
               block:
                 - name: Run role with invalid rhc_state value
-                  ansible.builtin.include_role:
-                    name: linux-system-roles.rhc
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     rhc_state: invalid_choice
               rescue:
@@ -87,8 +83,7 @@
             - name: Argument specs reject invalid rhc_insights.state choice
               block:
                 - name: Run role with invalid rhc_insights.state value
-                  ansible.builtin.include_role:
-                    name: linux-system-roles.rhc
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     rhc_state: absent
                     rhc_insights:
@@ -111,8 +106,7 @@
             - name: Argument specs reject invalid repository state choice
               block:
                 - name: Run role with invalid repository state value
-                  ansible.builtin.include_role:
-                    name: linux-system-roles.rhc
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     rhc_state: absent
                     rhc_repositories:
@@ -134,8 +128,7 @@
             - name: Argument specs reject non-boolean rhc_insights.autoupdate
               block:
                 - name: Run role with non-boolean rhc_insights.autoupdate
-                  ansible.builtin.include_role:
-                    name: linux-system-roles.rhc
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
                   vars:
                     rhc_state: absent
                     rhc_insights:
@@ -159,8 +152,7 @@
         - name: Assert rejects rhc_release as a list
           block:
             - name: Run role with rhc_release as a list
-              ansible.builtin.include_role:
-                name: linux-system-roles.rhc
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 rhc_state: absent
                 rhc_release:
@@ -181,8 +173,7 @@
         - name: Assert rejects rhc_baseurl as an integer
           block:
             - name: Run role with rhc_baseurl as an integer
-              ansible.builtin.include_role:
-                name: linux-system-roles.rhc
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 rhc_state: absent
                 rhc_baseurl: 123
@@ -202,8 +193,7 @@
         - name: Assert rejects rhc_insights.tags as a string
           block:
             - name: Run role with rhc_insights.tags as a string
-              ansible.builtin.include_role:
-                name: linux-system-roles.rhc
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 rhc_state: absent
                 rhc_insights:
@@ -226,8 +216,7 @@
         - name: Assert rejects rhc_insights.ansible_host as an integer
           block:
             - name: Run role with rhc_insights.ansible_host as an integer
-              ansible.builtin.include_role:
-                name: linux-system-roles.rhc
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
               vars:
                 rhc_state: absent
                 rhc_insights:
@@ -247,6 +236,77 @@
               assert_role_vars should reject rhc_insights.ansible_host
               when given an integer value
 
+        - name: Assert rejects rhc_auth with both login and activation_keys
+          block:
+            - name: Run role with conflicting rhc_auth methods
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                rhc_state: absent
+                rhc_auth:
+                  login:
+                    username: user
+                    password: pass
+                  activation_keys:
+                    keys:
+                      - key-1
+          rescue:
+            - name: Mark conflicting rhc_auth methods rejected
+              ansible.builtin.set_fact:
+                __invalid_input_rhc_auth_both_methods_failed: true
+
+        - name: Assert conflicting rhc_auth methods were rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_rhc_auth_both_methods_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject rhc_auth when both login and
+              activation_keys are specified
+
+        - name: Assert rejects activation_keys without rhc_organization
+          block:
+            - name: Run role with activation_keys but no organization
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                rhc_state: present
+                rhc_auth:
+                  activation_keys:
+                    keys:
+                      - key-1
+          rescue:
+            - name: Mark activation_keys without organization rejected
+              ansible.builtin.set_fact:
+                __invalid_input_activation_keys_no_org_failed: true
+
+        - name: Assert activation_keys without organization was rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_activation_keys_no_org_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject activation_keys when
+              rhc_organization is not set
+
+        - name: Assert rejects rhc_proxy state absent with extra fields
+          block:
+            - name: Run role with rhc_proxy state absent and hostname
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                rhc_state: absent
+                rhc_proxy:
+                  state: absent
+                  hostname: proxy.example.com
+          rescue:
+            - name: Mark rhc_proxy absent with extra fields rejected
+              ansible.builtin.set_fact:
+                __invalid_input_rhc_proxy_absent_extra_failed: true
+
+        - name: Assert rhc_proxy absent with extra fields was rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_rhc_proxy_absent_extra_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject rhc_proxy when state is absent
+              and other proxy fields are specified
+
       always:
         - name: Clear test facts
           ansible.builtin.set_fact:
@@ -260,4 +320,7 @@
             __invalid_input_rhc_baseurl_int_failed:
             __invalid_input_rhc_insights_tags_str_failed:
             __invalid_input_rhc_insights_ansible_host_int_failed:
+            __invalid_input_rhc_auth_both_methods_failed:
+            __invalid_input_activation_keys_no_org_failed:
+            __invalid_input_rhc_proxy_absent_extra_failed:
           tags: tests::cleanup


### PR DESCRIPTION
Enhancement: Added argument spec and assert role spec validation to the rhc role. Also wrote tests for it found in tests/tests_invalid_input.

Reason: Because it is a good addition to the linux-system-roles project.

Result: Successfully added it and prepared tests for it. I used AI during this implementation.

Issue Tracker Tickets (Jira or BZ if any): https://github.com/linux-system-roles/postfix/issues/206 https://redhat.atlassian.net/browse/RHELMISC-16008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for role configuration options, including supported types, defaults, required values, and choices.
  * Added clear validation errors for invalid subscription, Insights, proxy, repository, release, and connection settings.
  * Added checks preventing conflicting authentication methods and incomplete activation-key configuration.
  * Added validation that an absent proxy configuration cannot include additional proxy fields.

* **Tests**
  * Expanded coverage for invalid authentication, organization, proxy, and nested configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->