### PR TITLE
chore: Fix pep8 E501 line too long in rhsm_repository_python_36.py

### DIFF
--- a/library/rhsm_repository_python_36.py
+++ b/library/rhsm_repository_python_36.py
@@ -17,8 +17,8 @@ description:
     command.
 author: Giovanni Sciortino (@giovannisciortino)
 notes:
-  - In order to manage RHSM repositories the system must be already registered to RHSM manually or using the Ansible M(community.general.redhat_subscription)
-    module.
+  - In order to manage RHSM repositories the system must be already registered to RHSM manually or using the Ansible
+    M(community.general.redhat_subscription) module.
   - It is possible to interact with C(subscription-manager) only as root, so root permissions are required to successfully
     run this module.
 requirements:


### PR DESCRIPTION
Enhancement: Small fix to avoid long line in a python module

Reason: Long line was failing pep8 E501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reformatted a module documentation note for improved readability.
  - Placed the Red Hat subscription module reference on a separate continuation line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->